### PR TITLE
Changed Air Prediction from laguna madre to SBirdIsland

### DIFF
--- a/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
+++ b/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
@@ -27,7 +27,7 @@
         {  "key": "SemaphoreInputs",
          "args": {
             "column_name": "Air Temperature Prediction",
-            "location": "lagunamadre", 
+            "location": "SBirdIsland", 
             "source": "NDFD_EXP",
             "series": "pAirTemp",
             "interval": 3600,


### PR DESCRIPTION
Very dumb mistake on my end. At some point I got into my head that the air predictions are from laguna madre despite the actual measurements being from SBI. I have corrected the mistake.

How to test:
 - Change to the correct directory: `cd CDL-Broadcast`
 - Run containers
 - Run this command: `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json`
 - Check this url in the browser:  http://localhost:8080/flare/south-bird-island