### PR TITLE
The measurements and predictions will no longer be connected

### DIFF
--- a/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
+++ b/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
@@ -67,20 +67,6 @@
     ],
     "post_processing" : [
       {
-        "key": "AddMostRecentMeasurement",
-        "args": {
-              "measurement_col_key": "Air Temperature Measurement",
-              "prediction_col_key": "Air Temperature Prediction"
-        }
-      },
-      {
-        "key": "AddMostRecentMeasurement",
-        "args": {
-              "measurement_col_key": "Water Temperature Measurement",
-              "prediction_col_key": "Water Temperature Prediction"
-        }
-      },
-      {
         "key": "LinearInterpolation",
         "args": {
             "col_name": "Air Temperature Prediction",


### PR DESCRIPTION
Like the title says the measurements and predictions will no longer be connect to each other as it looks weird when the predictions are significantly higher than the measurements.

# How to test:
1. Build containers
2. Run this command: docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
3. Zoom into the graph and ensure measurements and predictions are separated.