### PR TITLE
540 temperatures should show with only 2 digits after the decimal point on graph

### DIFF
--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -428,7 +428,7 @@ const largeScreenChartOptions = ref({
                   hour: "2-digit",
                   minute: "2-digit",
               })}</b><br>
-              Temperature: ${this.y}°F`;
+              Temperature: ${this.y.toFixed(2)}°F`;
     },
     style: {
       fontSize: "14px",

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -222,7 +222,7 @@ const smallScreenChartOptions = ref({
                   hour: "2-digit",
                   minute: "2-digit",
               })}</b><br>
-              Temperature: ${this.y}°F`;
+              Temperature: ${this.y.toFixed(2)}°F`;
     },
     style: {
       fontSize: "12px",


### PR DESCRIPTION
Goal: Have temperature show with a 2 digits precision. 
This was a super simple fix, just two line changes. 

To test bring up the containers, run 'npm run dev',  visit 'http://localhost:8080/flare/south-bird-island' and hover over the temperature points to make sure there is only a 2 pint precision. 

![image](https://github.com/user-attachments/assets/5e8370f2-2db6-428a-9d66-7dad82a68c77)

VS

![image](https://github.com/user-attachments/assets/30b0b682-9242-4950-ba5b-011076f1886b)
