### PR TITLE
51 bug updating our deploy scripts to version 28 of docker

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,20 +2,26 @@
 
 # A script that deploys flare and initializes its cron file.
 
-#Update to latest version of main
-git fetch origin --tags $1 
+# Lower active containers
+docker-compose down
+
+# Fetch origin            vvvvvv - This will delete any tags that origin has deleted
+git fetch origin --tags --prune --prune-tags
+
+# Checkout correct tag
+git checkout $1
 
 #Pull changes from tag
 git pull 
 
 #Remove first docker containers
-docker-compose down
+docker compose down
 
 #Build docker containers
-docker-compose build
+docker compose build
 
 #Launch docker containers
-docker-compose up -d
+docker compose up -d
 
 #Remove existing cron file
 crontab -r

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 # A script that deploys flare and initializes its cron file.
 
 # Lower active containers
-docker-compose down
+docker compose down
 
 # Fetch origin            vvvvvv - This will delete any tags that origin has deleted
 git fetch origin --tags --prune --prune-tags


### PR DESCRIPTION
## OverView
Changed the deployment script to work with version 28 of docker and added the git 'fetch origin --tags --prune --prune-tags' command because i believe that was the command that allows us to roll back while in development because it uses the most recent tag and when the tag is deleted it will go back to the tag previous. (If i remember right, I could be wrong though)
## Testing
docker compose build
docker compose up -d
docker exec semaphore-core python3 tools/migrate_db.py

LMK if i did anything wrong :)