### PR TITLE
81 remove extrapolation in ndfd data in ensemble graphs

### DIFF
--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -28,14 +28,6 @@
     ],
     "post_processing" : [
       {
-        "key": "LinearInterpolation",
-        "args": {
-            "col_name": "NDFD Air Temperature Predictions",
-            "interpolation_interval": 3600,
-            "limit": 10800
-        }
-      },
-      {
          "key": "RowStatistics",
          "args": { 
                "metrics": "median",

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 15
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 15
+            "limit": 10800
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -30,7 +30,7 @@
       {
         "key": "LinearInterpolation",
         "args": {
-          "col_name": "NDFD Air Temperature Predictions",
+            "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
             "limit": 10800
           }

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -21,7 +21,7 @@
             "source": "NDFD_EXP",
             "series": "pAirTemp",
             "interval": 3600,
-            "range": [0, 240]
+            "range": [0, 144]
          }
             
       }

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
           "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 30
+            "limit": 10800
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -28,6 +28,14 @@
     ],
     "post_processing" : [
       {
+        "key": "LinearInterpolation",
+        "args": {
+          "col_name": "NDFD Air Temperature Predictions",
+            "interpolation_interval": 3600,
+            "limit": 30
+          }
+      },
+      {
          "key": "RowStatistics",
          "args": { 
                "metrics": "median",

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 15
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 15
+            "limit": 10800
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -30,7 +30,7 @@
       {
         "key": "LinearInterpolation",
         "args": {
-          "col_name": "NDFD Air Temperature Predictions",
+            "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
             "limit": 10800
           }

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -28,6 +28,14 @@
     ],
     "post_processing" : [
       {
+        "key": "LinearInterpolation",
+        "args": {
+          "col_name": "NDFD Air Temperature Predictions",
+            "interpolation_interval": 3600,
+            "limit": 30
+          }
+      },
+      {
          "key": "RowStatistics",
          "args": { 
                "metrics": "all",

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -21,7 +21,7 @@
             "source": "NDFD_EXP",
             "series": "pAirTemp",
             "interval": 3600,
-            "range": [0, 240]
+            "range": [0, 144]
         }
             
       }

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -28,14 +28,6 @@
     ],
     "post_processing" : [
       {
-        "key": "LinearInterpolation",
-        "args": {
-            "col_name": "NDFD Air Temperature Predictions",
-            "interpolation_interval": 3600,
-            "limit": 10800
-        }
-      },
-      {
          "key": "RowStatistics",
          "args": { 
                "metrics": "all",

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
           "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 30
+            "limit": 10800
           }
       },
       {

--- a/vue-ui/src/views/AirTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/AirTemperatureEnsembleView.vue
@@ -28,9 +28,14 @@ const state = reactive({
 // spaghetti graph
 // ribbon graph
 // box plot graph
-const csvURL = ref(`${window.location.origin}/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-const csvURL2 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-const csvURL3 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
+//const csvURL = ref(`${window.location.origin}/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+//const csvURL2 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+//const csvURL3 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
+
+const csvURL = ref(`http://localhost:8080/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+const csvURL2 = ref(`http://localhost:8080/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+const csvURL3 = ref(`http://localhost:8080/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
+
 
 // Add reactive state for dropdown visibility
 const isExportMenuVisible = ref(false);
@@ -485,6 +490,14 @@ const buildThirdChart = (isSmallScreen) => {
         padding: isSmallScreen ? "5px" : "8px", 
         color: "#0f4f66",
         fontFamily: "Arial",
+      },
+    },
+    plotOptions: {
+      line: {
+        lineWidth: 3
+      },
+      spline: {
+      lineWidth: 3
       },
     },
   }

--- a/vue-ui/src/views/AirTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/AirTemperatureEnsembleView.vue
@@ -28,13 +28,10 @@ const state = reactive({
 // spaghetti graph
 // ribbon graph
 // box plot graph
-//const csvURL = ref(`${window.location.origin}/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-//const csvURL2 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-//const csvURL3 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
+const csvURL = ref(`${window.location.origin}/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+const csvURL2 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
+const csvURL3 = ref(`${window.location.origin}/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
 
-const csvURL = ref(`http://localhost:8080/flare/csv-data/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-const csvURL2 = ref(`http://localhost:8080/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.csv`);
-const csvURL3 = ref(`http://localhost:8080/flare/csv-data/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.csv`);
 
 
 // Add reactive state for dropdown visibility


### PR DESCRIPTION
To run:

1. `docker compose down`
2. `docker compose up --build -d`
3. run `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`

`docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json`

`docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`

4. http://localhost:8080/flare/air-temperature-ensemble
5. see charts 

Changes:
- Median line on box plot graph was made thicker to match ribbon graph median line
- NDFD hours requested for both ribbon graph and box plot CSV files was changed from [0, 240] -> [0, 144] to make 6 days (6 * 24) hours requested.