### PR TITLE
90 change linear interpolation to consecutive nans instead of cumulative nans

### DIFF
--- a/backend/PostProcessing/PostProcessingClasses/LinearInterpolation.py
+++ b/backend/PostProcessing/PostProcessingClasses/LinearInterpolation.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-#ImmediateArithmeticOperation.py
+# LinearInterpolation.py
 #-------------------------------
-# Created By : Matthew Kastl
+# Created By: Christian Quintero
+# Last Updated: 08/04/2025
 #-------------------------------
-""" The post processing in this file preforms an linear interpolation of a column.
+""" The post processing in this file performs a linear interpolation of a column.
  """ 
 #-------------------------------
 # 
@@ -24,7 +25,7 @@ class LinearInterpolation(IPostProcessing):
             df DataFrame: The DataFrame containing this collation of the data that has been collected.
             col_name: str - The column in the DataFrame to interpolate.
             interpolation_interval: int - The interval to interpolate data on, in seconds.
-            limit: int - The amount of Nan's in a row it will interpolate.
+            limit: int - The amount of Nan's consecutive NaNs in a row to interpolate.
 
         Returns:
             DataFrame : A new dataframe obj might have to be created, this will always be a reference to the most updated version.
@@ -41,7 +42,7 @@ class LinearInterpolation(IPostProcessing):
             }
         },
         """
-        
+
         # Isolate the data we are going to interpolate
         data = df[col_name]
 
@@ -49,22 +50,29 @@ class LinearInterpolation(IPostProcessing):
         # the data to the specific interval we want to interpolate on.
         data = data.reindex(date_range(start=data.index[0], end=data.index[-1], freq=timedelta(seconds=interpolation_interval)))
 
-        # We want to not interpolate if there are too many Nans in a row. However the pandas limit parameter only stops interpolation once its
-        # counted a cumulative sum of Nans higher than limit. Thus it keeps the Nans in that group where the cumulative sum was still < limit.
-        # The forwards cumulative mask looks for where this mistake will happen thus used to overwrite the interpolated values with Nan.
+        # We want to 'mask' the data so that each value gets assigned TRUE if NaN and FALSE if it is a real value.
         nan_mask = data.isna()
-        cumulative_nan_streaks = nan_mask.groupby(~nan_mask).cumsum()
-        forward_cumulative_nan_mask = cumulative_nan_streaks.gt(limit)
 
-        # We do the interpolation backwards because a forwards cumulative mask was easier to write than a backwards one.
-        backwards_interpolation = data.interpolate(method= 'time', limit= limit, limit_area= 'inside', limit_direction= 'backward')
-        
-        # Here we repair the mistake by looking at the forward cumulative mask and inserting Nan.
-        backwards_interpolation[forward_cumulative_nan_mask] = np.nan
-   
-        # Outer join to preserve all data in the dataframe.
+        # Create unique group IDs for consecutive NaN streaks.
+        group_ids = (~nan_mask).cumsum()
+
+        # Count the length of each NaN streak
+        # For each group ID, count how many NaN values (True values in nan_mask) are in that group
+        streak_lengths = nan_mask.groupby(group_ids).transform('sum')   
+
+        # Create a mask for NaN streaks longer than the limit
+        # We only want to mark actual NaN positions that are in long streaks
+        long_streak_mask = (streak_lengths > limit) & nan_mask
+
+        # Interpolate all NaN values using time-based interpolation, which is the same as linear interpolation
+        interpolated_data = data.interpolate(method='time', limit_area='inside')
+
+        # Put NaNs back where streaks were too long
+        # aka where the NaN streaks > limit
+        interpolated_data[long_streak_mask] = np.nan
+
+        # Replace the original column with our processed data
         df.drop(columns=[col_name], inplace=True)
-        df = df.join(backwards_interpolation, how='outer')
+        df = df.join(interpolated_data, how='outer')
         return df
-
 

--- a/backend/PostProcessing/PostProcessingClasses/LinearInterpolation.py
+++ b/backend/PostProcessing/PostProcessingClasses/LinearInterpolation.py
@@ -25,7 +25,7 @@ class LinearInterpolation(IPostProcessing):
             df DataFrame: The DataFrame containing this collation of the data that has been collected.
             col_name: str - The column in the DataFrame to interpolate.
             interpolation_interval: int - The interval to interpolate data on, in seconds.
-            limit: int - The amount of Nan's consecutive NaNs in a row to interpolate.
+            limit: int - The amount of consecutive NaNs in a row to interpolate.
 
         Returns:
             DataFrame : A new dataframe obj might have to be created, this will always be a reference to the most updated version.

--- a/backend/Tests/UnitTests/test_LinearInterpolation.py
+++ b/backend/Tests/UnitTests/test_LinearInterpolation.py
@@ -128,7 +128,7 @@ expected_df1, expected_df2, expected_df3, expected_df4, expected_df5 = create_ex
 
 ])
 def test_interpolation(test_df: DataFrame, expected_df: DataFrame, col_name: str, interpolation_interval: int, limit: int):
-    """Test Linear Interpolation PPC with the first test data frame"""
+    """Test Linear Interpolation PPC with the parametrized test data frames"""
 
     kwargs = {
         "col_name": col_name,                                # col to interpolate

--- a/backend/Tests/UnitTests/test_LinearInterpolation.py
+++ b/backend/Tests/UnitTests/test_LinearInterpolation.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 #test_LinearInterpolation.py
 #-------------------------------
-# Created By: Matthew Kastl
+# Created By: Christian Quintero
+# Last Updated: 08/05/2025
 #----------------------------------
-"""This file tests the ImmediateArithmeticOperation PPC 
+"""This file tests the LinearInterpolation PPC 
+    
+    Important: It should be noted that at the time of writing this (08/05/2025), the linear interpolationg
+    is expected to work by counting where gaps of 5 consecutive NaNs will occur, and interpolating over those gaps
+    between 2 real values. If the gap between 2 real values has 6+ NaNs, no linear interpolation should occur, and any gap 
+    <= 5 should be interpolated.
  """ 
 #----------------------------------
 # 
@@ -12,84 +18,128 @@ import sys
 sys.path.append('/app/backend')
 
 import pytest
+import pandas as pd
 from math import isclose
 from pandas import DataFrame, date_range, read_csv, Series
 from numpy import nan
 from datetime import datetime
 from PostProcessing.IPostProcessing import post_process_factory
 
+# This method makes some dummy test data with various lengths and has various NaN streak lengths
+# to be used to test that the interpolation is working as expected.
+def create_test_data():
+    """Create test DataFrames with intentional NaN streaks of various lengths"""
+    
+    # Create a time index
+    index = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=20, freq='1min')
+    
+    # Test case 1: Mixed short and long streaks.
+    data1 = [1.0, nan, nan, nan, 5.0, nan, nan, nan, nan, nan, nan, 12.0, nan, nan, 15.0, 16.0, nan, nan, nan, nan]
+    df1 = DataFrame({'test_col': data1}, index=index)
+    
+    # Test case 2: Exactly at the limit
+    data2 = [1.0, nan, nan, nan, nan, nan, 7.0, nan, nan, nan, nan, nan, 14.0]
+    index2 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=13, freq='1min')
+    df2 = DataFrame({'test_col': data2}, index=index2)
+    
+    # Test case 3: Single NaN values (should always interpolate)
+    data3 = [1.0, nan, 3.0, nan, 5.0, nan, 7.0]
+    index3 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=7, freq='1min')
+    df3 = DataFrame({'test_col': data3}, index=index3)
+    
+    # Test case 4: NaN streaks at beginning and end (edge cases)
+    data4 = [nan, nan, nan, 4.0, nan, nan, nan, nan, nan, 10.0, nan, nan, nan]
+    index4 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=13, freq='1min')
+    df4 = DataFrame({'test_col': data4}, index=index4)
 
-series = {'data6Min': [val for val in range(101)]} # 10 hours of 5min data
-index = date_range(datetime(2024, 1, 1, 0, 0, 0), periods=len(series['data6Min']), freq='6min')
-df_6min = DataFrame(series, index=index)
+    # Test case 5: Clear long streak that definitely shouldn't interpolate
+    data5 = [1.0, nan, nan, nan, nan, nan, nan, nan, 9.0] 
+    index5 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=9, freq='1min')
+    df5 = DataFrame({'test_col': data5}, index=index5)
 
-series = {'data5hr': [val for val in range(3)]} # 10 hours of 5min data
-index = date_range(datetime(2024, 1, 1, 0, 0, 0), periods=len(series['data5hr']), freq='5h')
-df_5hr = DataFrame(series, index=index)
-
-series = {'data1hr': [val for val in range(11)]} # 10 hours of 5min data
-index = date_range(datetime(2024, 1, 1, 0, 0, 0), periods=len(series['data1hr']), freq='1h')
-df_1hr = DataFrame(series, index=index)
-
-one_hour_to_six_min_interpolation = df_6min.join(df_1hr, how='outer')['data1hr'].interpolate(method='time')
-five_hour_to_ten_hour_interpolation = df_1hr.join(df_5hr, how='outer')['data5hr'].interpolate(method='time')
+    return df1, df2, df3, df4, df5
 
 
-@pytest.mark.parametrize("df_data, col_name, interpolation_interval, limit, expected_results", [
-    # Tests interpolation into a dataframe of the same index resolution
-    (df_6min.join(df_1hr, how='outer'), 'data1hr', 360, 500, one_hour_to_six_min_interpolation), 
-    # Tests interpolation into a dataframe with a higher index resolution
-    (df_6min.join(df_1hr, how='outer').join(df_5hr, how='outer'), 'data5hr', 3600, 500, five_hour_to_ten_hour_interpolation), 
-    # Tests interpolation into a dataframe with a lower index resolution
-    (df_1hr.join(df_5hr, how='outer'), 'data1hr', 360, 500, one_hour_to_six_min_interpolation),
+def create_expected_data():
+    """Creates the expected data frames to be compared to the test data"""
+    
+    # Create the same time indices as the test data
+    index  = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=20, freq='1min')
+    index2 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=13, freq='1min')
+    index3 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=7, freq='1min')
+    index4 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=13, freq='1min')
+    index5 = date_range(datetime(2025, 1, 1, 0, 0, 0), periods=9, freq='1min')
+    
+    # Expected case 1: Mixed short and long streaks
+    # Original: [1.0, nan, nan, nan, 5.0, nan, nan, nan, nan, nan, nan, 12.0, nan, nan, 15.0, 16.0, nan, nan, nan, nan]
+    # Gap 1: 3 NaNs between 1.0 and 5.0 → interpolate (2.0, 3.0, 4.0)
+    # Gap 2: 6 NaNs between 5.0 and 12.0 → DON'T interpolate (leave as NaN)
+    # Gap 3: 2 NaNs between 12.0 and 15.0 → interpolate (13.0, 14.0)
+    # Gap 4: 4 NaNs at end after 16.0 → leave as NaN (no endpoint to interpolate to)
+    expected_data1 = [1.0, 2.0, 3.0, 4.0, 5.0, nan, nan, nan, nan, nan, nan, 12.0, 13.0, 14.0, 15.0, 16.0, nan, nan, nan, nan]
+    expected_df1 = DataFrame({'test_col': expected_data1}, index=index)
+    
+    # Expected case 2: Exactly at the limit
+    # Original: [1.0, nan, nan, nan, nan, nan, 7.0, nan, nan, nan, nan, nan, 14.0]
+    # Gap 1: 5 NaNs between 1.0 and 7.0 → interpolate (2.0, 3.0, 4.0, 5.0, 6.0)
+    # Gap 2: 5 NaNs between 7.0 and 14.0 → interpolate 
+    # Step size for gap 2: (14.0 - 7.0) / 6 = 7.0 / 6 ≈ 1.1667
+    # Values: 7 + 1.1667 = 8.1667, 7 + 2*1.1667 = 9.3333, 7 + 3*1.1667 = 10.5, 7 + 4*1.1667 = 11.6667, 7 + 5*1.1667 = 12.8333
+    expected_data2 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.166666666666666, 9.333333333333334, 10.5, 11.666666666666666, 12.833333333333334, 14.0]
+    expected_df2 = DataFrame({'test_col': expected_data2}, index=index2)
+
+
+    # Expected case 3: Single NaN values (should always interpolate)
+    # Original: [1.0, nan, 3.0, nan, 5.0, nan, 7.0]
+    # All gaps are 1 NaN → interpolate all
+    expected_data3 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    expected_df3 = DataFrame({'test_col': expected_data3}, index=index3)
+    
+    # Expected case 4: NaN streaks at beginning and end (edge cases)
+    # Original: [nan, nan, nan, 4.0, nan, nan, nan, nan, nan, 10.0, nan, nan, nan]
+    # Gap 1: 3 NaNs at beginning → leave as NaN (no starting point)
+    # Gap 2: 5 NaNs between 4.0 and 10.0 → interpolate
+    # Step size: (10.0 - 4.0) / 6 = 6.0 / 6 = 1.0
+    # Values: 4 + 1 = 5.0, 4 + 2 = 6.0, 4 + 3 = 7.0, 4 + 4 = 8.0, 4 + 5 = 9.0
+    # Gap 3: 3 NaNs at end → leave as NaN (no endpoint)
+    expected_data4 = [nan, nan, nan, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, nan, nan, nan]
+    expected_df4 = DataFrame({'test_col': expected_data4}, index=index4)
+    
+    # Expected case 5: Clear long streak that definitely shouldn't interpolate
+    # Original: [1.0, nan, nan, nan, nan, nan, nan, nan, 9.0]
+    # Gap: 7 NaNs between 1.0 and 9.0 → DON'T interpolate (≥6 NaNs)
+    expected_data5 = [1.0, nan, nan, nan, nan, nan, nan, nan, 9.0]
+    expected_df5 = DataFrame({'test_col': expected_data5}, index=index5)
+
+    return expected_df1, expected_df2, expected_df3, expected_df4, expected_df5
+
+
+# Create the test data and expected data frames
+test_df1, test_df2, test_df3, test_df4, test_df5 = create_test_data()
+expected_df1, expected_df2, expected_df3, expected_df4, expected_df5 = create_expected_data()
+
+
+@pytest.mark.parametrize("test_df, expected_df, col_name, interpolation_interval, limit", [
+    (test_df1, expected_df1, "test_col", 60, 5),
+    (test_df2, expected_df2, "test_col", 60, 5),
+    (test_df3, expected_df3, "test_col", 60, 5),
+    (test_df4, expected_df4, "test_col", 60, 5),
+    (test_df5, expected_df5, "test_col", 60, 5)
+
 ])
-def test_post_process_data(df_data: DataFrame, col_name: str, interpolation_interval: int, limit: int, expected_results: Series):
-    """This function tests that the interpolation function is generating the correct values as requested.
-    """
+def test_interpolation(test_df: DataFrame, expected_df: DataFrame, col_name: str, interpolation_interval: int, limit: int):
+    """Test Linear Interpolation PPC with the first test data frame"""
 
-    call = "LinearInterpolation"
     kwargs = {
-        "col_name": col_name,
-        "interpolation_interval": interpolation_interval,
-        "limit": limit
+        "col_name": col_name,                                # col to interpolate
+        "interpolation_interval": interpolation_interval,    #
+        "limit": limit                                       # how many consecutive NaNs to interpolate over
     }
 
-    # Call the factory to get the resolver and pass it the fake input data and the post process call
-    df_data = post_process_factory(df_data, call, kwargs)
 
-    # Unpack the resulting components
-    result = df_data[col_name].dropna().tolist()
-    expected = expected_results.tolist()
+    # call the post processing factory with to interpolate the first test data frame
+    result_df = post_process_factory(test_df, "LinearInterpolation", kwargs)
+    
 
-    # Iterate through the resulting components checking if they were calculated correctly
-    for actual, expected in zip(result, expected):
-        tolerance = 1e-5
-        if not isclose(actual, expected, abs_tol=tolerance):
-            assert False
-    assert True
-
-
-
-@pytest.mark.parametrize("df_data, col_name, interpolation_interval, limit, expected_results", [
-    # Tests interpolation into a dataframe of the same index resolution
-    (df_6min.join(df_1hr, how='outer'), 'data1hr', 360, 500, 101), 
-    # Tests interpolation into a dataframe with a higher index resolution
-    (df_6min.join(df_1hr, how='outer').join(df_5hr, how='outer'), 'data5hr', 3600, 500, 101), 
-    # Tests interpolation into a dataframe with a lower index resolution
-    (df_1hr.join(df_5hr, how='outer'), 'data1hr', 360, 500, 101),
-])
-def test_post_process_data_indexing(df_data: DataFrame, col_name: str, interpolation_interval: int, limit: int, expected_results: Series):
-    """This function tests that no bad reindexing side effects are occurring.
-    """
-
-    call = "LinearInterpolation"
-    kwargs = {
-        "col_name": col_name,
-        "interpolation_interval": interpolation_interval,
-        "limit": limit
-    }
-
-    # Call the factory to get the resolver and pass it the fake input data and the post process call
-    df_data = post_process_factory(df_data, call, kwargs)
-    assert len(df_data) == expected_results
-
+    # compare the data frames 
+    pd.testing.assert_frame_equal(result_df, expected_df, rtol=1e-9)

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 5
           }
       },
       {

--- a/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
+++ b/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json
@@ -32,7 +32,7 @@
         "args": {
             "col_name": "NDFD Air Temperature Predictions",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 5
           }
       },
       {


### PR DESCRIPTION
To run pytests:
* First run pytests. I ran this with my virtual environment setup through a windows terminal, so commands may be different if you are using Linux
1. activate venv 
2. run pytests `docker exec flare-backend python3 -m pytest`. 

To run the rest:
1. wsl 
2. `docker compose down`
3. `docker compose up --build -d`
4. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json` for building the CSV for ribbon graph
5. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json` for building CSV for box plot graph
6. http://localhost:8080/flare/air-temperature-ensemble to see charts

* Note that at the time of writing this, we are aware of the missing data from TWC, so only the NDFD line will appear. The PR focuses on changing the NDFD line, so it is ok that TWC data is missing. 



Example output:
<img width="2190" height="1136" alt="image" src="https://github.com/user-attachments/assets/94539fe7-ac67-454b-90ba-1e280c8c3587" />


Changes:
* Linear interpolation PPC now interpolates gaps of NaNs that are <= the "limit" variable rather than cumulative NaNs.
* Limit in ribbon graph and box plot CSPEC changed to -> 5. Means that 5 NaNs in a row or less get interpolated.
* Unit test file for Linear interpolation PPC file updated. Tested with a limit of 5 and hard coded values in the test file for using a limit of 5. 

