### PR TITLE
98 add a warning banner to flare when missing data

### DIFF
--- a/vue-ui/src/components/MissingDataWarningBanner.vue
+++ b/vue-ui/src/components/MissingDataWarningBanner.vue
@@ -1,0 +1,93 @@
+<!-- ===================================================
+     Component: MissingDataWarningBanner.vue
+     Description: 
+        This is a warning data to be used on pages with charts. 
+        checkForMissingDataAndWarn can be called to show the chart if 
+        any charts contain missing data.
+     Author: Matthew Kastl
+     Date: 8/27/2025
+======================================================= -->
+
+<template>
+    <div class="missing-data-warning-banner">
+        {{ bannerText }}
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+const bannerText = ref('');
+
+// Functions to show and hide the banner on a page
+function showBanner(text) {
+    bannerText.value = text;
+    const banner = document.querySelector('.missing-data-warning-banner');
+    if (banner) {
+        banner.style.display = '';
+    }
+}
+
+function hideBanner() {
+    const banner = document.querySelector('.missing-data-warning-banner');
+    if (banner) {
+        banner.style.display = 'none';
+    }
+}
+
+ /**
+ * This function is to be called externally to check for missing data in a pages charts
+ * and show the warning banner if any missing data is found
+ * @param {Array.<Object>} charts A list of each chart to check for missing data
+ * @returns {void}
+ */
+const checkForMissingDataAndWarn = (charts) => {
+    const moreThanOneChart = charts.length > 1;
+    charts.forEach(chart => {
+        let chartHasMissingData = false;
+        if (!chart.series || chart.series.length === 0) {
+            console.warn("A Warning banner will be displayed to user. No series found in chart:", chart);
+            chartHasMissingData = true;
+        }
+        else {
+            chart.series.forEach(series => {
+                if (!series.data || series.data.length === 0) {
+                    console.warn("A Warning banner will be displayed to user. Missing data in series:", series);
+                    chartHasMissingData = true;
+                }
+            });
+        }
+
+        if (chartHasMissingData) {
+            showBanner(`Warning: ${moreThanOneChart ? 'Charts' : 'Chart'} may be inaccurate due to missing data.`);
+        } else {
+            hideBanner();
+        }
+    });
+}
+defineExpose({ checkForMissingDataAndWarn });
+
+hideBanner(); // Hide by default
+</script>
+
+
+<style scoped>
+.missing-data-warning-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100vw;
+    background-color: #fffbe6;
+    text-align: center;
+    color: #856404;
+    padding: 16px;
+    text-align: center;
+    border: 1px solid #ffe58f;
+    box-sizing: border-box;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+}
+
+</style>

--- a/vue-ui/src/views/AirTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/AirTemperatureEnsembleView.vue
@@ -20,6 +20,9 @@ import { Chart } from "highcharts-vue";
 
 import { ref, onMounted, onUnmounted, reactive } from "vue";
 
+import MissingDataWarningBanner from "@/components/MissingDataWarningBanner.vue";
+const missingDataWarningBanner = ref(MissingDataWarningBanner);
+
 // Using reactive state to track if the screen is small
 const state = reactive({ 
   isSmallScreen: window.innerWidth <= 600
@@ -863,14 +866,23 @@ const toggleThirdExportMenu = () => {
 ///Fetch and update chart data every 15 minutes
 let updateInterval;
 onMounted(() => {
-  fetchAndFilterData(); 
-  fetchAndFilterSecondData();
-  fetchAndFilterThirdData();
+  Promise.all([
+    fetchAndFilterData(),
+    fetchAndFilterSecondData(),
+    fetchAndFilterThirdData()
+  ]).then(() => {
+    missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value, secondChartOptions.value, thirdChartOptions.value]);
+  });
+  
   updateInterval = setInterval(() => {
     console.log("Fetching and updating chart data...");
-    fetchAndFilterData();
-    fetchAndFilterSecondData();
-    fetchAndFilterThirdData();
+    Promise.all([
+      fetchAndFilterData(),
+      fetchAndFilterSecondData(),
+      fetchAndFilterThirdData(),
+    ]).then(() => {
+      missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value, secondChartOptions.value, thirdChartOptions.value]);
+    });
   }, 900000); 
 });
 
@@ -900,7 +912,7 @@ onUnmounted(() => {
         </div>
       </div>
       </section>
-
+      <MissingDataWarningBanner ref="missingDataWarningBanner" />
       <!-- First Chart Section: Spaghetti Graph -->
       <section class="grid grid-cols-1 lg:grid-cols-5 gap-4 py-8 px-4 bg-white items-stretch">
         <!-- Chart -->

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -16,6 +16,9 @@ import { Chart } from "highcharts-vue";
 
 import { ref, onMounted, onUnmounted, reactive } from "vue";
 
+import MissingDataWarningBanner from "@/components/MissingDataWarningBanner.vue";
+const missingDataWarningBanner = ref(MissingDataWarningBanner);
+
 // Using reactive state to track if the screen is small
 const state = reactive({
   isSmallScreen: window.innerWidth <= 600
@@ -434,11 +437,15 @@ const toggleExportMenu = () => {
 ///Fetch and update chart data every 15 minutes
 let updateInterval;
 onMounted(() => {
-  fetchAndFilterData();
+  fetchAndFilterData().then(() => {
+
+  });
   window.addEventListener('resize', handleResize);
   updateInterval = setInterval(() => {
     console.log("Fetching and updating chart data...");
-    fetchAndFilterData();
+    fetchAndFilterData().then(() => {
+      missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value]);
+    });
   }, 900000); 
 });
 
@@ -469,7 +476,7 @@ onUnmounted(() => {
       </div>
     </div>
   </section>
-
+  <MissingDataWarningBanner ref="missingDataWarningBanner" />
   <!-- Chart Section -->
   <section class="grid grid-cols-1 lg:grid-cols-5 gap-4 py-8 px-4 bg-white items-stretch">
   <!-- Chart -->

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -24,7 +24,8 @@ const state = reactive({
   isSmallScreen: window.innerWidth <= 600
 });
 
-const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
+// const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
+const csvURL = ref(`http://localhost:8080/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
 
 // Add reactive state for dropdown visibility
 const isExportMenuVisible = ref(false);
@@ -438,7 +439,7 @@ const toggleExportMenu = () => {
 let updateInterval;
 onMounted(() => {
   fetchAndFilterData().then(() => {
-
+    missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value]);
   });
   window.addEventListener('resize', handleResize);
   updateInterval = setInterval(() => {

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -24,8 +24,7 @@ const state = reactive({
   isSmallScreen: window.innerWidth <= 600
 });
 
-// const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
-const csvURL = ref(`http://localhost:8080/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
+const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
 
 // Add reactive state for dropdown visibility
 const isExportMenuVisible = ref(false);

--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -20,6 +20,9 @@ import { Chart } from "highcharts-vue";
 
 import { ref, onMounted, onUnmounted, reactive } from "vue";
 
+import MissingDataWarningBanner from "@/components/MissingDataWarningBanner.vue";
+const missingDataWarningBanner = ref(MissingDataWarningBanner);
+
 const isSmallScreen = window.innerWidth <= 600;
 const csvURL = ref(`${window.location.origin}/flare/csv-data/MRE_Bird-Island_Water-Temperature.csv`);
 
@@ -450,10 +453,14 @@ const toggleExportMenu = () => {
 ///Fetch and update chart data every 15 minutes
 let updateInterval;
 onMounted(() => {
-  fetchAndFilterData(); 
+  fetchAndFilterData().then(() => {
+    missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value]);
+  });
   updateInterval = setInterval(() => {
     console.log("Fetching and updating chart data...");
-    fetchAndFilterData();
+    fetchAndFilterData().then(() => {
+    missingDataWarningBanner.value.checkForMissingDataAndWarn([chartOptions.value]);
+  });
   }, 900000); 
 });
 


### PR DESCRIPTION
# Why?
We want a warning banner to dynamically pop up for the user when there is a full series missing in a chart. 

# How
1) I defined a new component `MissingDataWarningBanner.vue` to encapsulate the code/style/structure of the banner
2) I added the banner to each of the three pages that contain charts
3) I added a call to the banner after the data is loaded on the page to have it check for missing data and either disable itself or reveal itself

# How does it look?
<img width="1500" height="322" alt="image" src="https://github.com/user-attachments/assets/71adb8f1-dda4-43a0-a1a3-1d9b8638fe61" />

Pretty good id say and I used an off yellow just for you @lovelysandlonelys ! But lmk if you think there is a way to improve it, its really easy to change.


<img width="552" height="175" alt="image" src="https://github.com/user-attachments/assets/82fa88da-88e5-44b2-a6e4-67de97ce43c4" />

Works on mobile too!

It also will show what it detected as missing as warnings in the console (we really need to clean this console up!
<img width="671" height="242" alt="image" src="https://github.com/user-attachments/assets/b4fd968d-05ef-4855-b9c3-dd2ac789dbe9" />

# How to test?
1) Pull changes and build container `docker compose up --build -d`
2) Look at charts. Depending on what csvs you have saved you will either see a banner or not. Remember you should see the banner if at least one series on one chart is missing! If you see one you can look at the console to see whats missing

