### PR TITLE
93 fix sbi graphs to show higher values on graph

### DIFF
--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -250,6 +250,7 @@ const buildChart = (isSmallScreen) => {
   };
 };
 
+
 const handleResize = () => {
   state.isSmallScreen = window.innerWidth <= 600;
   chartOptions.value = buildChart(state.isSmallScreen);


### PR DESCRIPTION
### What changed
The hardcoded maximum for the y axis was changed to be a softMax, that way if data goes above 90 the chart will auto extend. A little padding was also added to have a little extra space on top of the highest value.

### To Test
- build containers
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json` to build chart
- go to http://localhost:8080/flare/south-bird-island to see chart results

### Expected output
<img width="2148" height="1190" alt="image" src="https://github.com/user-attachments/assets/57b0e1d8-0395-4fae-bf6b-6553bc49bcb3" />
