### PR TITLE
103-change-y-axis-on-mre-graphs-to-use-soft-max-and-padding

### DIFF
--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -190,9 +190,10 @@ const buildChart = (isSmallScreen) => {
           fontSize: isSmallScreen ? "12px" : "20px", 
         },
       },
-      max: 90,
+      softMax: 90,      // Stay at 90°F when data is below it
       min: 20,
       tickInterval: 10, // Add ticks every 10 units
+      maxPadding: 0.05, // Add padding only when data exceeds 90°F
       plotLines: [
         {
           color: "red",


### PR DESCRIPTION
### What was changed
In the Vue file for the water temp graph, I added a softMax and padding to the y-axis so that when values go over the softMax (90 in our case) the chart auto extends and adds a little extra room, causing the chart to register 100 and 110 (and more ticks if needed) when values go over 90. 

### How did you test
- I made the CSV for this chart and it seems to be a bit cooler, as non of the values were above 90, so the chart looked normal.
- I had AI increase each value by 5, causing the entire CSV data to be 5C higher than what would have actually been made, then looked at the chart where 100 and 110 show correctly that the chart extends when needed.

### How should I test
- `docker compose down`
- `docker compose up --build -d`
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json` to create water temp graph
- Go to http://localhost:8080/flare/water-temperature-ensemble
- download the file with increased temperatures and replace the previous CSV.
[MRE_Bird-Island_Water-Temperature.csv](https://github.com/user-attachments/files/22416211/MRE_Bird-Island_Water-Temperature.csv)


- Go to http://localhost:8080/flare/water-temperature-ensemble and check that the y-axis extended above 90


### Expected output

Regular
<img width="2156" height="1138" alt="image" src="https://github.com/user-attachments/assets/d21b05a4-d8f1-48fe-918a-b722e35c755c" />



+5C
<img width="2172" height="1090" alt="image" src="https://github.com/user-attachments/assets/8ba7d904-0118-4604-b2f4-9e6ec41dd9a4" />

