### PR TITLE
Altering to an unsecured context if we are hitting sherlock-dev

### DIFF
--- a/backend/Ingestion/Ingestion_Utility.py
+++ b/backend/Ingestion/Ingestion_Utility.py
@@ -4,6 +4,7 @@ from numpy import nan
 from pandas import DataFrame
 import json
 from runtimeContext import thread_storage
+import ssl
 
 
 def api_request( url: str):
@@ -14,7 +15,9 @@ def api_request( url: str):
     """
     logger = thread_storage.logger
     try:
-        with urlopen(url) as response:
+        # As of writing this 10/26/2025 sherlock-dev has no ssl cert, so if we are hitting the dev server we disable ssl verification
+        context = ssl.create_default_context() if not "sherlock-dev" in url else ssl._create_unverified_context()
+        with urlopen(url, context=context) as response:
             data = json.loads(''.join([line.decode() for line in response.readlines()])) #Download and parse
         return data
     except HTTPError as err:


### PR DESCRIPTION
# Why?

As sherlock-dev no longer has an SSL cert, we need to make a request that is not reliant on a valid https endpoint. This was done by setting an unsecured context in the request ONLY if we are hitting a request within sherlock-dev

<img width="1108" height="119" alt="image" src="https://github.com/user-attachments/assets/dd0d817f-33d6-45a7-967a-86f4fa531f00" />


# Test
1. Build flare containers `docker compose up --build -d` 
2. Run `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`
3. Notice there is no SSL error response from the API trying to request NDFD data. (it might still error out see other prs but if things are organized how I think they are you should only see a 500 error)