### PR TITLE
fixed a bug from using scatter series types

### DIFF
--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -367,7 +367,8 @@ const fetchAndFilterData = async () => {
         name: "Air Temperature Predictions",
         data: AirPredictionMarkers,
         color: "green",
-        type: "scatter",
+        type: "line",
+        lineWidth: 0,   // No line, just markers
         marker: {
           enabled: true,
           radius: isSmallScreen ? 1.9 : 2.5,
@@ -377,7 +378,8 @@ const fetchAndFilterData = async () => {
         name: "Water Temperature Predictions",
         data: WaterTemperatureMarkers,
         color: "purple",
-        type: "scatter",
+        type: "line",
+        lineWidth: 0,   // No line, just markers
         marker: {
           enabled: true,
           radius: isSmallScreen ? 1.9 : 2.5,


### PR DESCRIPTION
### Issue
In my testing, I found that only the water ribbon graph couldn't scroll properly left and right or up and down when you touched on the graph itself. The issue is using the "scatter" graph type for a few of the series which are causing touch interactions to be messed with not allowing swiping or scrolling.

### The Solution
I changed the scatter type to be a line type with a line width of 0 so that visually, the graphs look the exact same before and after the changes but now you can scroll the graph and page properly. 

### To test
1. `docker compose up --build -d`
2. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json`
3. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json`
4. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`
5. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`
6. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json`
7. go to http://localhost:8080/flare/ and use F12 to change your screen into a phone screen. Make sure touch simulation is active otherwise your screen may not scroll at all. 
8. Ensure the SBI graph, water ribbon graph, and all 3 air temperature graphs (spaghetti, ribbon, box plot) all display properly and scroll left/right/up/down properly


### The touch simulation button must be active
<img width="1552" height="1462" alt="image" src="https://github.com/user-attachments/assets/f84cc9ae-236a-4562-b43b-15e7bfa54cd4" />
