### PR TITLE
fixed refactored api parsing

### DIFF
--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
@@ -57,10 +57,32 @@ class SemaphoreOutputLatest(IDataIngestion):
     
     
     def __add_data(self, df: DataFrame, response: dict[any], model_names: list[str], col_name: str) -> DataFrame:
-        '''Takes the data returned by the semaphore API, parses it into a pandas series, and adds it to the
-        dataframe with all the other data.'''
+        '''
+        Takes the data returned by the semaphore API, parses it into a pandas series, and adds it to the
+        dataframe with all the other data.
+
+        MRE models (1, 100, 1) have the structure of
+        [
+            [
+                [20.776033401489258],
+                [20.255704879760742],
+                [20.67584228515625],
+                ...
+                [21.035802841186523]
+            ]
+        ]
+
+        Legacy models (1, 1, 1) have the structure of
+        [
+            [
+                [22.00688934326172]
+            ]
+        ]        
+        '''
         index = []
         data = []
+        expected_shapes = [(1, 100, 1), (1, 1, 1)]
+        logger = thread_storage.logger
         for name in model_names:
             model_response  = response[name]
 
@@ -71,39 +93,26 @@ class SemaphoreOutputLatest(IDataIngestion):
             index.append(verifiedTime)
 
             value = data_point['dataValue']
-            if value is None or value == 'None':
-                value = np.nan
-                data.append(value)
+            if value in (None, 'None', []):
+                data.append(np.nan)
             
+            elif np.array(value).shape not in expected_shapes:
+                # validate the response data matches one of the expected shapes
+                logger.log_error(f'Warning:: Model {name} returned data with unexpected shape {np.array(value).shape}!', include_traceback=False)
+                data.append(np.nan)
+
             elif 'MRE' in name:
-                """
-                MRE models (1, 100, 1) have the structure of
-                [
-                    [
-                        [20.776033401489258],
-                        [20.255704879760742],
-                        [20.67584228515625],
-                        ...
-                        [21.035802841186523]
-                    ]
-                ]
-                """
-                # flatten MRE models into 1 array with the structure of [1.0, 2.0, ...]
-                # then append the array
-                flat_array = np.array(value[0]).flatten().tolist()
+                # flatten MRE models into 1 array and convert to floats
+                # the flat array has the structure of [1.0, 2.0, ...]
+                # then append the flattened array
+                flat_array = np.asarray(value[0], dtype=float).flatten().tolist()
                 data.append(flat_array)
 
             else:
-                """
-                (1, 1, 1) models have the structure of
-                [
-                    [
-                        [22.00688934326172]
-                    ]
-                ]
-                """
                 # append the single value
-                data.append(value[0][0][0])
+                # the appended value is a scalar such as 1.0, not an array
+                single_value = float(value[0][0][0])
+                data.append(single_value)
 
         # Add this to the collation df with an outerjoin to ensure all data is preserved
         return df.join(DataFrame({col_name: data}, index=index), how='outer')

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
@@ -83,9 +83,9 @@ class SemaphoreOutputLatest(IDataIngestion):
         data = []
         expected_shapes = [(1, 100, 1), (1, 1, 1)]
         logger = thread_storage.logger
+
         for name in model_names:
             model_response  = response[name]
-
             data_point = model_response['_Series__data'][0]
 
             timeGenerated = datetime.strptime(data_point['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
@@ -93,12 +93,14 @@ class SemaphoreOutputLatest(IDataIngestion):
             index.append(verifiedTime)
 
             value = data_point['dataValue']
+            shape = np.array(value).shape
+
             if value in (None, 'None', []):
                 data.append(np.nan)
             
-            elif np.array(value).shape not in expected_shapes:
+            elif shape not in expected_shapes:
                 # validate the response data matches one of the expected shapes
-                logger.log_error(f'Warning:: Model {name} returned data with unexpected shape {np.array(value).shape}!', include_traceback=False)
+                logger.log_error(f'Warning:: Model {name} returned data with unexpected shape {shape}!', include_traceback=False)
                 data.append(np.nan)
 
             elif 'MRE' in name:

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
@@ -81,7 +81,6 @@ class SemaphoreOutputLatest(IDataIngestion):
         '''
         index = []
         data = []
-        expected_shapes = [(1, 100, 1), (1, 1, 1)]
         logger = thread_storage.logger
 
         for name in model_names:
@@ -97,24 +96,25 @@ class SemaphoreOutputLatest(IDataIngestion):
 
             if value in (None, 'None', []):
                 data.append(np.nan)
-            
-            elif shape not in expected_shapes:
-                # validate the response data matches one of the expected shapes
-                logger.log_error(f'Warning:: Model {name} returned data with unexpected shape {shape}!', include_traceback=False)
-                data.append(np.nan)
 
-            elif 'MRE' in name:
+            elif shape == (1, 100, 1):
                 # flatten MRE models into 1 array and convert to floats
                 # the flat array has the structure of [1.0, 2.0, ...]
                 # then append the flattened array
                 flat_array = np.asarray(value[0], dtype=float).flatten().tolist()
                 data.append(flat_array)
 
-            else:
+            elif shape == (1, 1, 1):
                 # append the single value
                 # the appended value is a scalar such as 1.0, not an array
                 single_value = float(value[0][0][0])
                 data.append(single_value)
+            
+            else:
+                # if not an expected shape, log an error and append NaN
+                logger.log_error(f'Warning:: Model {name} returned data with unexpected shape {shape}!', include_traceback=False)
+                data.append(np.nan)
+
 
         # Add this to the collation df with an outerjoin to ensure all data is preserved
         return df.join(DataFrame({col_name: data}, index=index), how='outer')

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputLatest.py
@@ -15,8 +15,8 @@ from datetime import datetime, timedelta
 from Ingestion.Ingestion_Utility import api_request, add_empty_column
 from flareRunner import thread_storage 
 from pandas import DataFrame
-from numpy import nan
 from os import getenv
+import numpy as np
 
 
 class SemaphoreOutputLatest(IDataIngestion):
@@ -71,14 +71,39 @@ class SemaphoreOutputLatest(IDataIngestion):
             index.append(verifiedTime)
 
             value = data_point['dataValue']
-            if value is None or value == 'None': value = nan
+            if value is None or value == 'None':
+                value = np.nan
+                data.append(value)
             
-            elif isinstance(value, list):
-                # Convert all elements to float
-                value = [float(v) for v in value]
-            
-            else: value = float(value)
-            data.append(value)
+            elif 'MRE' in name:
+                """
+                MRE models (1, 100, 1) have the structure of
+                [
+                    [
+                        [20.776033401489258],
+                        [20.255704879760742],
+                        [20.67584228515625],
+                        ...
+                        [21.035802841186523]
+                    ]
+                ]
+                """
+                # flatten MRE models into 1 array with the structure of [1.0, 2.0, ...]
+                # then append the array
+                flat_array = np.array(value[0]).flatten().tolist()
+                data.append(flat_array)
+
+            else:
+                """
+                (1, 1, 1) models have the structure of
+                [
+                    [
+                        [22.00688934326172]
+                    ]
+                ]
+                """
+                # append the single value
+                data.append(value[0][0][0])
 
         # Add this to the collation df with an outerjoin to ensure all data is preserved
         return df.join(DataFrame({col_name: data}, index=index), how='outer')

--- a/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
+++ b/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+# test_Combine.py
+#-------------------------------
+# Created By: Christian Quintero
+#----------------------------------
+"""
+This file tests the SemaphoreOutputLatest data ingestion class.
+
+NOTE:: these tests don't actually call the SemaphoreOutputLatest class
+but instead use the same logic to test the parsing and validation of the API response
+
+docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py -v
+""" 
+#----------------------------------
+# 
+#
+import pytest
+import numpy as np
+from pandas import DataFrame
+from datetime import datetime, timedelta
+
+
+
+# NOTE:: nulls were replaced with None, true was changed to True,
+# and the data value was changed to 1.0 for simplicity
+# to test legacy models work as expected
+response = {
+  "Bird-Island_Water-Temperature_120hr": {
+    "description": {
+      "modelName": "Bird-Island_Water-Temperature_120hr",
+      "modelVersion": "1.0.0",
+      "dataSeries": "pWaterTmp",
+      "dataLocation": "SouthBirdIsland",
+      "dataDatum": None
+    },
+    "timeDescription": None,
+    "isComplete": True,
+    "_Series__data": [
+      {
+        "dataValue": [
+          [
+            [
+              1.0
+            ]
+          ]
+        ],
+        "dataUnit": "celsius",
+        "timeGenerated": "2026-03-18T15:00:00",
+        "leadTime": 432000
+      }
+    ]
+  }
+}
+
+# NOTE:: nulls were replaced with None, true was changed to True,
+# and the data values were changed for simplicity
+# to test normal MRE data works as expected
+mre_response = {
+  "MRE_Bird-Island_Water-Temperature_120hr": {
+    "description": {
+      "modelName": "MRE_Bird-Island_Water-Temperature_120hr",
+      "modelVersion": "1.0.0",
+      "dataSeries": "pWaterTmp",
+      "dataLocation": "SouthBirdIsland",
+      "dataDatum": None
+    },
+    "timeDescription": None,
+    "isComplete": True,
+    "_Series__data": [
+      {
+        "dataValue": [
+          [
+            [1.0],  [2.0],  [3.0],  [4.0],  [5.0],  [6.0],  [7.0],  [8.0],  [9.0],  [10.0],
+            [11.0], [12.0], [13.0], [14.0], [15.0], [16.0], [17.0], [18.0], [19.0], [20.0],
+            [21.0], [22.0], [23.0], [24.0], [25.0], [26.0], [27.0], [28.0], [29.0], [30.0],
+            [31.0], [32.0], [33.0], [34.0], [35.0], [36.0], [37.0], [38.0], [39.0], [40.0],
+            [41.0], [42.0], [43.0], [44.0], [45.0], [46.0], [47.0], [48.0], [49.0], [50.0],
+            [51.0], [52.0], [53.0], [54.0], [55.0], [56.0], [57.0], [58.0], [59.0], [60.0],
+            [61.0], [62.0], [63.0], [64.0], [65.0], [66.0], [67.0], [68.0], [69.0], [70.0],
+            [71.0], [72.0], [73.0], [74.0], [75.0], [76.0], [77.0], [78.0], [79.0], [80.0],
+            [81.0], [82.0], [83.0], [84.0], [85.0], [86.0], [87.0], [88.0], [89.0], [90.0],
+            [91.0], [92.0], [93.0], [94.0], [95.0], [96.0], [97.0], [98.0], [99.0], [100.00]
+          ]
+        ],
+        "dataUnit": "celsius",
+        "timeGenerated": "2026-03-18T15:00:00",
+        "leadTime": 432000
+      }
+    ]
+  }
+}
+
+# to test that when dataValue is missing, nan is appended
+missing_data_value = {
+  "Bird-Island_Water-Temperature_120hr": {
+    "description": {
+      "modelName": "Bird-Island_Water-Temperature_120hr",
+      "modelVersion": "1.0.0",
+      "dataSeries": "pWaterTmp",
+      "dataLocation": "SouthBirdIsland",
+      "dataDatum": None
+    },
+    "timeDescription": None,
+    "isComplete": True,
+    "_Series__data": [
+      {
+        "dataValue": [],
+        "dataUnit": "celsius",
+        "timeGenerated": "2026-03-18T15:00:00",
+        "leadTime": 432000
+      }
+    ]
+  }
+}
+
+# to test that bad shapes are caught and nan is appended
+# this case uses has a shape of (1)
+sinlge_list_value = {
+  "Bird-Island_Water-Temperature_120hr": {
+    "description": {
+      "modelName": "Bird-Island_Water-Temperature_120hr",
+      "modelVersion": "1.0.0",
+      "dataSeries": "pWaterTmp",
+      "dataLocation": "SouthBirdIsland",
+      "dataDatum": None
+    },
+    "timeDescription": None,
+    "isComplete": True,
+    "_Series__data": [
+      {
+        "dataValue": [1.0],
+        "dataUnit": "celsius",
+        "timeGenerated": "2026-03-18T15:00:00",
+        "leadTime": 432000
+      }
+    ]
+  }
+}
+
+# to test that bad shapes are caught and nan is appended
+# this case uses (2, 1, 1)
+two_one_one = {
+    "Bird-Island_Water-Temperature_120hr": {
+    "description": {
+      "modelName": "Bird-Island_Water-Temperature_120hr",
+      "modelVersion": "1.0.0",
+      "dataSeries": "pWaterTmp",
+      "dataLocation": "SouthBirdIsland",
+      "dataDatum": None
+    },
+    "timeDescription": None,
+    "isComplete": True,
+    "_Series__data": [
+      {
+        "dataValue": [
+            [
+                [1.0]
+            ],
+            [
+                [2.0]
+            ]
+        ],
+        "dataUnit": "celsius",
+        "timeGenerated": "2026-03-18T15:00:00",
+        "leadTime": 432000
+      }
+    ]
+  }
+}
+
+@pytest.mark.parametrize(
+    "response, name, expected_data",
+    [
+        (response, "Bird-Island_Water-Temperature_120hr", 1.0),
+        (mre_response, "MRE_Bird-Island_Water-Temperature_120hr",
+            [
+                1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
+                11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+                21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0,
+                31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0,
+                41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.00,
+                51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0, 59.0, 60.0,
+                61.0, 62.0, 63.0, 64.0, 65.0, 66.0, 67.0, 68.0, 69.0, 70.0,
+                71.0, 72.0, 73.0, 74.0, 75.0, 76.0, 77.0, 78.0, 79.0, 80.0,
+                81.0, 82.0, 83.0, 84.0, 85.0, 86.0, 87.0, 88.0, 89.0, 90.0,
+                91.0, 92.0, 93.0, 94.0, 95.0, 96.0, 97.0, 98.0, 99.0, 100.00
+            ]
+        )
+    ],
+    ids = [
+        "Legacy Model Response",
+        "MRE Model Response"
+    ]
+)
+def test_add_data(response, name, expected_data):
+    """
+    tests the __add_data function for the new parsing logic from the semaphore CRPS refactor
+
+    NOTE:: This test doesn't actually call the __add_data function, but uses the same logic
+
+    docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py::test_add_data -v
+    """
+    index = []
+    data = []
+    expected_shapes = [(1, 100, 1), (1, 1, 1)]
+
+    model_response  = response[name]
+    data_point = model_response['_Series__data'][0]
+
+    timeGenerated = datetime.strptime(data_point['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
+    verifiedTime = timeGenerated + timedelta(seconds=data_point['leadTime'])
+    index.append(verifiedTime)
+    value = data_point['dataValue']
+
+    # assert regular responses pass the expected shape check
+    assert np.array(value).shape in expected_shapes
+
+    # test the flattening
+    # the array should have the shape of [1.0, 2.0, ..., 100.0]
+    if 'MRE' in name:
+        flat_array = np.asarray(value[0], dtype=float).flatten().tolist()
+        data.append(flat_array)
+    
+    # test the single value parsing
+    # the data appended should be a scalar such as 1.0, not an array
+    else:
+        single_value = float(value[0][0][0])
+        data.append(single_value)
+    
+    assert data[0] == expected_data
+
+@pytest.mark.parametrize(
+    "response, name",
+    [
+        (missing_data_value, "Bird-Island_Water-Temperature_120hr"),
+        (sinlge_list_value, "Bird-Island_Water-Temperature_120hr"),
+        (two_one_one, "Bird-Island_Water-Temperature_120hr")
+    ],
+    ids = [
+        "Missing Data Value",
+        "Bad Shape",
+        "2x1x1 Shape"
+    ]
+)
+def test_add_data_nan_cases(response, name):
+    """
+    test the nan cases for __add_data, such as missing data values and bad shapes
+
+    NOTE:: this test doesn't actually call the __add_data function, but uses the same logic
+
+    docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py::test_add_data_nan_cases -v
+    """
+    index = []
+    data = []
+    expected_shapes = [(1, 100, 1), (1, 1, 1)]
+    bad_shapes = [sinlge_list_value, two_one_one]
+
+    model_response  = response[name]
+    data_point = model_response['_Series__data'][0]
+
+    timeGenerated = datetime.strptime(data_point['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
+    verifiedTime = timeGenerated + timedelta(seconds=data_point['leadTime'])
+    index.append(verifiedTime)
+    value = data_point['dataValue']
+
+    
+    if response == missing_data_value:
+        # test that when dataValue is missing, nan is appended
+        assert value in (None, 'None', [])
+        data.append(np.nan)
+    else:
+        # test that the bad shape cases are caught and nan is appended
+        assert np.array(value).shape not in expected_shapes
+        data.append(np.nan)
+
+    # assert that the data looks like [nan]
+    assert np.isnan(data[0])
+
+        
+

--- a/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
+++ b/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-# test_Combine.py
+# test_SemaphoreOutputLatest.py
 #-------------------------------
 # Created By: Christian Quintero
+# 03/18/2026
 #----------------------------------
 """
 This file tests the SemaphoreOutputLatest data ingestion class.
-
-NOTE:: these tests don't actually call the SemaphoreOutputLatest class
-but instead use the same logic to test the parsing and validation of the API response
 
 docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py -v
 """ 
@@ -17,9 +15,9 @@ docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_Se
 import pytest
 import numpy as np
 from pandas import DataFrame
-from datetime import datetime, timedelta
-
-
+from unittest.mock import MagicMock
+from flareRunner import thread_storage
+from Ingestion.IngestionClasses.SemaphoreOutputLatest import SemaphoreOutputLatest
 
 # NOTE:: nulls were replaced with None, true was changed to True,
 # and the data value was changed to 1.0 for simplicity
@@ -115,7 +113,7 @@ missing_data_value = {
 
 # to test that bad shapes are caught and nan is appended
 # this case uses has a shape of (1)
-sinlge_list_value = {
+single_list_value = {
   "Bird-Island_Water-Temperature_120hr": {
     "description": {
       "modelName": "Bird-Island_Water-Temperature_120hr",
@@ -185,96 +183,43 @@ two_one_one = {
                 81.0, 82.0, 83.0, 84.0, 85.0, 86.0, 87.0, 88.0, 89.0, 90.0,
                 91.0, 92.0, 93.0, 94.0, 95.0, 96.0, 97.0, 98.0, 99.0, 100.00
             ]
-        )
+        ),
+        (missing_data_value, "Bird-Island_Water-Temperature_120hr", np.nan),
+        (single_list_value, "Bird-Island_Water-Temperature_120hr", np.nan),
+        (two_one_one, "Bird-Island_Water-Temperature_120hr", np.nan)
     ],
     ids = [
         "Legacy Model Response",
-        "MRE Model Response"
+        "MRE Model Response",
+        "Missing dataValue",
+        "Bad Shape: Single List",
+        "Bad Shape: (2, 1, 1)"
     ]
 )
 def test_add_data(response, name, expected_data):
     """
     tests the __add_data function for the new parsing logic from the semaphore CRPS refactor
 
-    NOTE:: This test doesn't actually call the __add_data function, but uses the same logic
-
     docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py::test_add_data -v
     """
-    index = []
-    data = []
-    expected_shapes = [(1, 100, 1), (1, 1, 1)]
+    nan_tests = [missing_data_value, single_list_value, two_one_one]
+    ingestor = SemaphoreOutputLatest()
+    thread_storage.logger = MagicMock()
 
-    model_response  = response[name]
-    data_point = model_response['_Series__data'][0]
+    result_df = ingestor._SemaphoreOutputLatest__add_data(
+        df = DataFrame(),
+        response = response,
+        model_names = [name],
+        col_name = 'test_col'
+    )
 
-    timeGenerated = datetime.strptime(data_point['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
-    verifiedTime = timeGenerated + timedelta(seconds=data_point['leadTime'])
-    index.append(verifiedTime)
-    value = data_point['dataValue']
+    result_col = result_df['test_col']
 
-    # assert regular responses pass the expected shape check
-    assert np.array(value).shape in expected_shapes
-
-    # test the flattening
-    # the array should have the shape of [1.0, 2.0, ..., 100.0]
-    if 'MRE' in name:
-        flat_array = np.asarray(value[0], dtype=float).flatten().tolist()
-        data.append(flat_array)
-    
-    # test the single value parsing
-    # the data appended should be a scalar such as 1.0, not an array
+    if response in nan_tests:
+        assert np.isnan(result_col.iloc[0])
     else:
-        single_value = float(value[0][0][0])
-        data.append(single_value)
+        assert result_col.iloc[0] == expected_data
     
-    assert data[0] == expected_data
+    print(f'\n\n\nResult DF: {result_df}\n result col: {result_col}\n\n\n')
 
-@pytest.mark.parametrize(
-    "response, name",
-    [
-        (missing_data_value, "Bird-Island_Water-Temperature_120hr"),
-        (sinlge_list_value, "Bird-Island_Water-Temperature_120hr"),
-        (two_one_one, "Bird-Island_Water-Temperature_120hr")
-    ],
-    ids = [
-        "Missing Data Value",
-        "Bad Shape",
-        "2x1x1 Shape"
-    ]
-)
-def test_add_data_nan_cases(response, name):
-    """
-    test the nan cases for __add_data, such as missing data values and bad shapes
-
-    NOTE:: this test doesn't actually call the __add_data function, but uses the same logic
-
-    docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py::test_add_data_nan_cases -v
-    """
-    index = []
-    data = []
-    expected_shapes = [(1, 100, 1), (1, 1, 1)]
-    bad_shapes = [sinlge_list_value, two_one_one]
-
-    model_response  = response[name]
-    data_point = model_response['_Series__data'][0]
-
-    timeGenerated = datetime.strptime(data_point['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
-    verifiedTime = timeGenerated + timedelta(seconds=data_point['leadTime'])
-    index.append(verifiedTime)
-    value = data_point['dataValue']
-
-    
-    if response == missing_data_value:
-        # test that when dataValue is missing, nan is appended
-        assert value in (None, 'None', [])
-        data.append(np.nan)
-    else:
-        # test that the bad shape cases are caught and nan is appended
-        assert np.array(value).shape not in expected_shapes
-        data.append(np.nan)
-
-    # assert that the data looks like [nan]
-    assert np.isnan(data[0])
-
-        
 

--- a/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
+++ b/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py
@@ -219,7 +219,5 @@ def test_add_data(response, name, expected_data):
         assert np.isnan(result_col.iloc[0])
     else:
         assert result_col.iloc[0] == expected_data
-    
-    print(f'\n\n\nResult DF: {result_df}\n result col: {result_col}\n\n\n')
 
 


### PR DESCRIPTION
# What changed
With the new API changes in the Semaphore refactor, flare can't parse things. This is because now everything is wrapped in a 3D array, regardless of how many total values there are. This fix allows flare to parse API responses for outputs again.

# How to test
1. In the CRPS testing branch in semaphore, `docker compose up --build -d`
2. Run cold stunning models. See below for the full copy paste command for all models.
3. In Flare, ensure your env file has the Semahore API link pointing to your local semaphore api container
4. build containers in flare, `docker compose up --build -d`
5. run new tests `docker exec flare-backend python3 -m pytest /app/backend/Tests/UnitTests/test_SemaphoreOutputLatest.py -v`
6. build all the charts
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json` SBI graph
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json` MRE ribbon graph
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-Laguna-Madre_Air-Temperature-Predictions_240hrs.json` spaghetti graph
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json` TWC ribbon graph
- `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_Box-Plot_240hrs.json` TWC box plot graph
7. Compare built graphs to Semaphore dev or prod. I used prod to compare and the graphs were identical.

# Notes
* don't forget to run models at least 20 past the hour
* ensure no missing data banners appeared
* TWC and NDFD graphs (spaghetti, ribbon, box plot) should not have been changed since no select_input changes were made in the semaphore refactor, but it is good to test these still

# Expected output
<img width="1285" height="568" alt="image" src="https://github.com/user-attachments/assets/0be807fc-bdc9-4ad8-be83-bbd5025c3a37" />
<img width="1285" height="552" alt="image" src="https://github.com/user-attachments/assets/eabc1d74-20a9-4d2a-9ea2-37f27d331fbd" />

# Cold stunning model commands
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json`

`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json`
