### PR TITLE
fixed missing lead time markers bug

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,8 @@
 FRONTEND_HOST_PORT=8080
 SEMAPHORE_API_URL="https://sherlock-dev.tamucc.edu/semaphore-api/"
 
+# Semaphore runs models 20 minutes past the hour
+VITE_MODEL_RUN_TIME=20
+
 SERVICE_ACCOUNT_USERNAME=
 SERVICE_ACCOUNT_UID=

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,10 @@
 #Build node 22 image under the build name
 FROM node:22.10.0-slim AS build
 
+# get the model run time from the build args
+ARG VITE_MODEL_RUN_TIME
+ENV VITE_MODEL_RUN_TIME=$VITE_MODEL_RUN_TIME
+
 #Set the working directory 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: .   
       dockerfile: Dockerfile.frontend
       args:
-        - VITE_MODEL_RUN_TIME=${VITE_MODEL_RUN_TIME} # pass the model run time to the frontend build
+        VITE_MODEL_RUN_TIME: ${VITE_MODEL_RUN_TIME} # pass the model run time to the frontend build
     restart: always
     ports:
       - "${FRONTEND_HOST_PORT}:80"  # Host Port:Container Port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     container_name: flare-frontend
     build:
       context: .   
-      dockerfile: Dockerfile.frontend 
+      dockerfile: Dockerfile.frontend
+      args:
+        - VITE_MODEL_RUN_TIME=${VITE_MODEL_RUN_TIME} # pass the model run time to the frontend build
     restart: always
     ports:
       - "${FRONTEND_HOST_PORT}:80"  # Host Port:Container Port

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -269,12 +269,12 @@ const fetchAndFilterData = async () => {
     const InterpolatedWaterPredictionData = parsedData.waterPredictions || [];
     let referenceTime = new Date();
 
-    // if models haven't ran this hour then we use the 
+    // if models haven't run this hour then we use the 
     // previous top of the hour to calculate the hours difference correctly (aka lead times)
     if (referenceTime.getMinutes() < MODEL_RUN_TIME) {
       referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
     }
-    // if models have ran this hour then we can just use
+    // if models have run this hour then we can just use
     // the current time to calculate the hours difference and filter the data
     else {
       referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -22,6 +22,11 @@ const missingDataWarningBanner = ref(MissingDataWarningBanner);
 const isSmallScreen = window.innerWidth <= 600;
 const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv`);
 
+// the amount of minutes past the hour semaphore runs models
+const MODEL_RUN_TIME = import.meta.env.VITE_MODEL_RUN_TIME;
+// the lead times we actually predict to filter by
+const LEAD_TIMES = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
+
 // Add reactive state for dropdown visibility
 const isExportMenuVisible = ref(false);
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -262,17 +267,15 @@ const fetchAndFilterData = async () => {
     const AirMeasurementData = parsedData.airMeasurements || [];
     const InterpolatedAirPredictionData = parsedData.airPredictions || [];
     const InterpolatedWaterPredictionData = parsedData.waterPredictions || [];
+    let referenceTime = new Date();
 
-    // Filter `InterpolatedAirPrediction` to only include hourly data
-    const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
-    const referenceTime = new Date();
-
-    // if it's before the 20 minute mark, we use the previous top of the hour to 
-    // calculate the hours difference correctly (aka lead time)
-    if (referenceTime.getMinutes() < 20) {
+    // if models haven't ran this hour then we use the 
+    // previous top of the hour to calculate the hours difference correctly (aka lead times)
+    if (referenceTime.getMinutes() < MODEL_RUN_TIME) {
       referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
     }
-    // if it's past the 20 minute mark, we use the current top of the hour
+    // if models have ran this hour then we can just use
+    // the current time to calculate the hours difference and filter the data
     else {
       referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour
     }
@@ -280,14 +283,14 @@ const fetchAndFilterData = async () => {
     const AirPredictionData = InterpolatedAirPredictionData.filter((point) => {
       const pointTime = new Date(point[0]);
       const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
-      return hoursToFilter.includes(hoursDifference);
+      return LEAD_TIMES.includes(hoursDifference);
     });
 
     // Filter `InterpolatedWaterPrediction` for specific intervals
     const WaterPredictionData = InterpolatedWaterPredictionData.filter((point) => {
       const pointTime = new Date(point[0]);
       const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
-      return hoursToFilter.includes(hoursDifference);
+      return LEAD_TIMES.includes(hoursDifference);
     });
 
     // Convert all data to Fahrenheit

--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -26,11 +26,6 @@ const csvURL = ref(`${window.location.origin}/flare/csv-data/Laguna-Madre_Water-
 const isExportMenuVisible = ref(false);
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-
-// Define the current date and time
-const nowDate = new Date();// Current timestamp
-const nowTime = nowDate.getTime();
-
 const chartOptions = ref({});
 
 // Creating a single chart function that changes based on screen size
@@ -118,7 +113,7 @@ const buildChart = (isSmallScreen) => {
         {
           color: "red",
           width: 2,
-          value: nowTime,
+          value: Date.now(),
           dashStyle: "Solid",
           label: {
             text: "Now",
@@ -268,18 +263,30 @@ const fetchAndFilterData = async () => {
     const InterpolatedAirPredictionData = parsedData.airPredictions || [];
     const InterpolatedWaterPredictionData = parsedData.waterPredictions || [];
 
-     // Filter `InterpolatedAirPrediction` to only include hourly data
-     const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 102, 114, 120];
+    // Filter `InterpolatedAirPrediction` to only include hourly data
+    const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
+    const referenceTime = new Date();
+
+    // if it's before the 20 minute mark, we use the previous top of the hour to 
+    // calculate the hours difference correctly (aka lead time)
+    if (referenceTime.getMinutes() < 20) {
+      referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
+    }
+    // if it's past the 20 minute mark, we use the current top of the hour
+    else {
+      referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour
+    }
+
     const AirPredictionData = InterpolatedAirPredictionData.filter((point) => {
       const pointTime = new Date(point[0]);
-      const hoursDifference = Math.round((pointTime - nowTime) / (1000 * 60 * 60)); // Calculate hours difference
+      const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
       return hoursToFilter.includes(hoursDifference);
     });
 
     // Filter `InterpolatedWaterPrediction` for specific intervals
     const WaterPredictionData = InterpolatedWaterPredictionData.filter((point) => {
       const pointTime = new Date(point[0]);
-      const hoursDifference = Math.round((pointTime - nowTime) / (1000 * 60 * 60)); // Calculate hours difference
+      const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
       return hoursToFilter.includes(hoursDifference);
     });
 

--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -26,11 +26,14 @@ const missingDataWarningBanner = ref(MissingDataWarningBanner);
 const isSmallScreen = window.innerWidth <= 600;
 const csvURL = ref(`${window.location.origin}/flare/csv-data/MRE_Bird-Island_Water-Temperature.csv`);
 
+// the amount of minutes past the hour semaphore runs models
+const MODEL_RUN_TIME = import.meta.env.VITE_MODEL_RUN_TIME;
+// the lead times we actually predict to filter by
+const LEAD_TIMES = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
 
 // Add reactive state for dropdown visibility
 const isExportMenuVisible = ref(false);
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
 
 const chartOptions = ref({});
 
@@ -294,14 +297,17 @@ const fetchAndFilterData = async () => {
     const forecastAirTempsFahrenheit = forecastAirTemps.map(([time, celsius]) => [time, +toFahrenheit(celsius).toFixed(1)]);
 
     
-    const filterNonInterpolated = (data, hourFilter) => {
-      const referenceTime = new Date();
-      // if it's before the 20 minute mark, we use the previous top of the hour to 
-      // calculate the hours difference correctly (aka lead time)
-      if (referenceTime.getMinutes() < 20) {
+    const filterNonInterpolated = (data) => {
+      // get the current time
+      let referenceTime = new Date();
+
+      // if models haven't ran this hour then we use the 
+      // previous top of the hour to calculate the hours difference correctly (aka lead times)
+      if (referenceTime.getMinutes() < MODEL_RUN_TIME) {
         referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
       }
-      // if it's past the 20 minute mark, we use the current top of the hour
+      // if models have ran this hour then we can just use
+      // the current time to calculate the hours difference and filter the data
       else {
         referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour
       }
@@ -309,12 +315,11 @@ const fetchAndFilterData = async () => {
       return data.filter((point) => {
         const pointTime = new Date(point[0]);
         const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
-        return hourFilter.includes(hoursDifference);
+        return LEAD_TIMES.includes(hoursDifference);
       });
     };
-    const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
-    const AirPredictionMarkers = filterNonInterpolated(forecastAirTempsFahrenheit, hoursToFilter);
-    const WaterTemperatureMarkers = filterNonInterpolated(meanFahrenheit, hoursToFilter);
+    const AirPredictionMarkers = filterNonInterpolated(forecastAirTempsFahrenheit);
+    const WaterTemperatureMarkers = filterNonInterpolated(meanFahrenheit);
 
 
     // For highcharts to do a shaded range, it wants the range in the format of [date_index, lower_bound, upper_bound]

--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -32,10 +32,6 @@ const isExportMenuVisible = ref(false);
 const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 
-// Define the current date and time
-const nowDate = new Date();// Current timestamp
-const nowTime = nowDate.getTime();
-
 const chartOptions = ref({});
 
 
@@ -123,7 +119,7 @@ const buildChart = (isSmallScreen) => {
         {
           color: "red",
           width: 2,
-          value: nowTime,
+          value: Date.now(),
           dashStyle: "Solid",
           label: {
             text: "Now",
@@ -299,13 +295,24 @@ const fetchAndFilterData = async () => {
 
     
     const filterNonInterpolated = (data, hourFilter) => {
+      const referenceTime = new Date();
+      // if it's before the 20 minute mark, we use the previous top of the hour to 
+      // calculate the hours difference correctly (aka lead time)
+      if (referenceTime.getMinutes() < 20) {
+        referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
+      }
+      // if it's past the 20 minute mark, we use the current top of the hour
+      else {
+        referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour
+      }
+
       return data.filter((point) => {
         const pointTime = new Date(point[0]);
-        const hoursDifference = Math.round((pointTime - nowTime) / (1000 * 60 * 60)); // Calculate hours difference
+        const hoursDifference = Math.round((pointTime - referenceTime) / (1000 * 60 * 60)); // Calculate hours difference
         return hourFilter.includes(hoursDifference);
       });
     };
-    const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 102, 114, 120];
+    const hoursToFilter = [3, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120];
     const AirPredictionMarkers = filterNonInterpolated(forecastAirTempsFahrenheit, hoursToFilter);
     const WaterTemperatureMarkers = filterNonInterpolated(meanFahrenheit, hoursToFilter);
 

--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -301,12 +301,12 @@ const fetchAndFilterData = async () => {
       // get the current time
       let referenceTime = new Date();
 
-      // if models haven't ran this hour then we use the 
+      // if models haven't run this hour then we use the 
       // previous top of the hour to calculate the hours difference correctly (aka lead times)
       if (referenceTime.getMinutes() < MODEL_RUN_TIME) {
         referenceTime.setHours(referenceTime.getHours() - 1, 0, 0, 0); // set to the previous top of the hour
       }
-      // if models have ran this hour then we can just use
+      // if models have run this hour then we can just use
       // the current time to calculate the hours difference and filter the data
       else {
         referenceTime.setMinutes(0, 0, 0); // set to the current top of the hour


### PR DESCRIPTION
# The Changes
env.dist
- added a new variable that shows how many minutes past the hour semaphore runs models

Docker compose file
- added the new env variable to the frontend build

docker file for frontend container
- added the new env variable as a build arg to use

Vue files for Ensemble and Legacy
- updated calls that need the now time to call Date.now() directly
- defined LEAD_TIMES at the top of the module now
- defined new env var at the top of the module
- updated `filterNonInterpolated()` by removing a parameter (since its now a global constant in the module)

# Reasoning for new variable
Savannah had brought it up that hard coding a magic number of when the models run is not a good idea. From the current CSV files, the time generated is not a value present, so we can't directly just extract the time generated (aka reference time) from the CSV. Instead of doing some logic and math to calculate the reference time based on what is currently in the CSV, I decided added an env variable is simple and clean.

Benefits
- the new variable is not sensitive as it just represents the number of minutes past the hour semaphore runs models
- can be used throughout flare in the future in both the frontend and backend containers
- easy to update if we change the model run schedule of semaphore later on
- avoids hard coded values in many places by using 1 global variable instead

# How the changes fix the problem
When the CSV reaches the Vue pages, the page has to parse the raw CSV data to build the charts. From here, using a list of lead times we define, we filter the data rows to get the rows that are "real" predictions for the lead times we expect (aka the un-interpolated rows). The actual CSV rows go through some math to calculate that row's lead time from now, then if it lands on a lead time we expect, then it is a real prediction lead time. 

Because the interval filtering we do, if a row's calculated lead time does not land on any of the lead times in the LEAD_TIMES array, it is thrown out. This gets messy when new hours occur and we don't run models until 20 past the hour. 

What the fix does is that if the current time is before the MODEL_RUN_TIME (which is 20 minutes past the hour), then we set the reference time/generated time of the model predictions to the previous hour since the models were ran last hour. Ex) It is 1:15, so the time generated of our current predictions are 12:00 because we haven't run models for 1 yet.

If the current time is past the MODEL_RUN_TIME (aka it is currently 20 past the hour), then we set the reference time to now since we should have already run models for this current hour.
Ex) It is 1:20, so the time generated of our current predictions are 1:00 since we ran already ran models this hour.

Using the computed reference time, we then do the filtering calculations as previously handled before to ensure the lead times we expect land on our filter to display correctly.

In sum, if models haven't ran yet then use the previous hour as the reference time of the model runs. Else, use the current hour as the reference time.

# To test
The testing has 2 parts: testing when models have been ran this hour, and testing when models haven't yet been ran this hour

In a semaphore terminal and at least 20 past the hour:
1. run all the cold stunning models listed below (legacy and MRE)

In a Flare terminal
1. Copy the new lines from env.dist into your flare env file
2. `docker compose up --build -d`
3. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json`
4. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json`
5. go to `http://localhost:8080/flare/south-bird-island`

Now for both the south bird island graph and MRE graph, you should ensure you see the 21 lead time dots for both water and air temperature predictions. In my case, I ran all cold stunning models at 6:20 AM, and I confirmed the first lead time correctly shows a prediction for 9 AM (which is 6AM + 3 hour lead time).  You should confirm that your first lead time marker is in fact 3 hours from the current hour since you already ran models this hour.
<img width="2254" height="1122" alt="image" src="https://github.com/user-attachments/assets/8835f191-a48a-4e0d-8b2f-bfade77f3aee" />

---
After the turn of the next hour, rebuild the charts using steps 3 and 4. Since it is a new hour and models have not yet ran for this hour, you should still see all 21 lead time markers for both water and air temperature predictions and the first lead time marker is now 2 wall clock hours from now.

In my case since I ran models at 6:20 AM and it is now 7, those predictions from 6 are still valid since we haven't ran models for the current hour yet, so we should still display them. The charts are the same and the 3 hour lead time prediction is now 2 wall clock hours away from now since the 3 hour lead time is still based on the 6 AM reference time since models haven't ran for 7 yet.
<img width="2272" height="1136" alt="image" src="https://github.com/user-attachments/assets/ea6f3e0a-496e-437f-8d36-c7cb7fbe0e94" />


# All models
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json`

`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json`