### PR TITLE
857 flare add an ingestion class for ingesting statistics

### DIFF
--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -35,7 +35,9 @@ class SemaphoreOutputStatistics(IDataIngestion):
         validated_response = self.__validate_response(response)
 
         if validated_response is None:
-            return add_empty_column(data, "Water Temperature Prediction Statistics")
+            for stat in self.STATISTICS:
+                data = add_empty_column(data, f"Water Temperature Prediction {stat}")
+            return data
 
         return self.__add_data(df= data, response=validated_response)
 
@@ -158,10 +160,8 @@ class SemaphoreOutputStatistics(IDataIngestion):
             if match:
                 lead_time = int(match.group(1))
             else:
-                # in the case that a lead time isn't able to be extracted
-                # return the unmodified dataframe and log a warning
                 logger.log_info(f'Warning:: Could not extract lead time from model name {model_name}')
-                return df
+                continue
             
             timeGenerated = datetime.strptime(value['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
             verifiedTime = timeGenerated + timedelta(hours=lead_time)
@@ -170,6 +170,14 @@ class SemaphoreOutputStatistics(IDataIngestion):
             for stat in self.STATISTICS:
                 row[f'Water Temperature Prediction {stat}'] = value.get(stat, np.nan)
             rows.append(row)
+        
+        df_stats = DataFrame(rows)
+
+        # catch cases where models do give a valid response but all regex extractions fail
+        if df_stats.empty:
+            for stat in self.STATISTICS:
+                df = add_empty_column(df, f"Water Temperature Prediction {stat}")
+            return df
 
         df_stats = DataFrame(rows).set_index('verifiedTime')
 

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -24,7 +24,7 @@ class SemaphoreOutputStatistics(IDataIngestion):
         Ingests data from a Semaphore API endpoint
 
         :param data: dataframe - the dataframe object to fill with data
-        :param ref_time: datetime - the reference time for the data request
+        :param ref_time: datetime - the reference time for the data request, this is unused for this ingestion class
         :param model_names: list[str] - the names of the models to request data for
 
         :returns: dataframe - a new dataframe with the ingested data added
@@ -32,11 +32,12 @@ class SemaphoreOutputStatistics(IDataIngestion):
         url = self.__prepare_url(model_names)
 
         response = api_request(url)
-        is_valid_response = self.__validate_response(response, model_names)
-        if not is_valid_response:
+        validated_response = self.__validate_response(response)
+
+        if validated_response is None:
             return add_empty_column(data, "Water Temperature Prediction Statistics")
 
-        return self.__add_data(df= data, response=response, model_names=model_names)
+        return self.__add_data(df= data, response=validated_response)
 
 
     def __prepare_url(self, model_names: list[str]) -> str:
@@ -59,17 +60,69 @@ class SemaphoreOutputStatistics(IDataIngestion):
         return url[:-1]  # remove the trailing '&'
     
 
-    def __validate_response(self, response: list[dict], model_names: list[str]) -> bool:
+    def __validate_response(self, response: dict) -> dict[str, dict] | None:
         '''
         This function validates the response from the semaphore API by checking for
         empty responses and missing data
 
-        :params response: list[dict] - the response from the API request
+        :params response: dict - the response from the API request
             the response will look like 
-            [
-                {
+            {
+                "CRPS_6hr": {
                     "modelName": "CRPS_6hr",
-                    "timeGenerated": "2026-05-12T12:00:00+00:00",
+                    "timeGenerated": "2026-05-12T12:00:00",
+                    "p1": 25.20813787460327,
+                    "p5": 25.744343280792236,
+                    "p10": 25.94855365753174,
+                    "p25": 26.22447681427002,
+                    "p50": 26.485905647277832,
+                    "p75": 26.73847484588623,
+                    "p90": 27.00280132293701,
+                    "p95": 27.201376342773436,
+                    "p99": 27.95702182769775,
+                    "min": 22.700056076049805,
+                    "max": 29.92579460144043,
+                    "mean": 26.486501573524475,
+                    "std_dev": 0.48822468208073955
+                },
+                "model_that_doesn't_exit": null,
+                ...
+            }
+
+        :returns dict[str, dict] - a dictionary containing only valid data that has statistics or None if no valid data is present
+        '''
+        logger = thread_storage.logger
+        validated_response = {}
+
+        if response is None: 
+            return None
+        
+        # filter out nulls in the response to only include models that compute statistics
+        for key, value in response.items():
+            if value is None:
+                logger.log_info(f'Warning:: Model {key} missing in returned data!')
+                continue
+            else:
+                validated_response[key] = value
+
+        # catch cases where all models are missing or have no data
+        if validated_response == {}:
+            return None
+        else:
+            return validated_response
+    
+    
+    def __add_data(self, df: DataFrame, response: dict[str, dict]) -> DataFrame:
+        '''
+        Takes the validated response dict and adds it into the dataframe
+
+        :param df: dataframe - the dataframe to add the data to
+        :param response: dict[str, dict] - the validated response from the API request
+            the response will look like 
+            {
+                "CRPS_6hr": {
+                    "modelName": "CRPS_6hr",
+                    "timeGenerated": "2026-05-12T12:00:00",
                     "p1": 25.20813787460327,
                     "p5": 25.744343280792236,
                     "p10": 25.94855365753174,
@@ -85,84 +138,32 @@ class SemaphoreOutputStatistics(IDataIngestion):
                     "std_dev": 0.48822468208073955
                 },
                 ...
-            ]
-        :params model_names: list[str] - the names of the models we queried for
-
-        :returns: bool
-            - true if we got a valid response, even if there is missing data
-            - false if the response was empty
-        '''
-        logger = thread_storage.logger
-
-        if response is None: 
-            return False
-        
-        for dict in response:
-            model_name = dict.get("modelName")
-            if model_name is None: 
-                logger.log_info(f'Warning:: Model {model_name} missing in returned data!')
-                continue
-
-        return True
-    
-    
-    def __add_data(self, df: DataFrame, response: list[dict], model_names: list[str]) -> DataFrame:
-        '''
-        Takes the data returned by the semaphore API and parses it into the dataframe
-
-        :param df: dataframe - the dataframe to add the data to
-        :param response: list[dict] - the response from the API request
-            the response will look like 
-                [
-                    {
-                        "modelName": "CRPS_6hr",
-                        "timeGenerated": "2026-05-12T12:00:00+00:00",
-                        "p1": 25.20813787460327,
-                        "p5": 25.744343280792236,
-                        "p10": 25.94855365753174,
-                        "p25": 26.22447681427002,
-                        "p50": 26.485905647277832,
-                        "p75": 26.73847484588623,
-                        "p90": 27.00280132293701,
-                        "p95": 27.201376342773436,
-                        "p99": 27.95702182769775,
-                        "min": 22.700056076049805,
-                        "max": 29.92579460144043,
-                        "mean": 26.486501573524475,
-                        "std_dev": 0.48822468208073955
-                    },
-                    ...
-                ]
-        :param model_names: list[str] - the names of the models we queried for
+            }
 
         :returns: dataframe - the dataframe with the new data added
         '''
         logger = thread_storage.logger
 
         rows = []
-        for dict in response:
-            model_name  = dict['modelName']
-            ############################
-            # DONT FORGET TO REMOVE THE TZ INFO AFTER JOY UPDATES THE API
-            ############################
-            timeGenerated = datetime.strptime(dict['timeGenerated'], '%Y-%m-%dT%H:%M:%S%z')
-            timeGenerated = timeGenerated.replace(tzinfo=None) # remove timezone info for easier handling
-            
+        for _, value in response.items():
             '''
             since the lead time isn't explicitly given in the response, we have to
-            calculate it since the lead times are tied to the model name
+            extract it since the lead times are tied to the model name
             
             Ex) CRPS_6hr has a lead time of 6 hours, so the 6 is extracted and 6 hours are added
                 to the time generated to get the verified time which is used as the index for the data
             '''
+            model_name = value['modelName']
             lead_time = int(re.search(r'(\d+)hr', model_name).group(1))
+            timeGenerated = datetime.strptime(value['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
             verifiedTime = timeGenerated + timedelta(hours=lead_time)
+
             row = {'verifiedTime': verifiedTime}
             for stat in self.STATISTICS:
-                row[f'Water Temperature Prediction {stat}'] = dict.get(stat, np.nan)
+                row[f'Water Temperature Prediction {stat}'] = value.get(stat, np.nan)
             rows.append(row)
 
         df_stats = DataFrame(rows).set_index('verifiedTime')
 
-        # Add this to the collation df with an outerjoin to ensure all data is preserved
+        # join the data frames with an outer join to ensure all data is preserved
         return df.join(df_stats, how='outer')

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -154,6 +154,8 @@ class SemaphoreOutputStatistics(IDataIngestion):
             
             Ex) CRPS_6hr has a lead time of 6 hours, so the 6 is extracted and 6 hours are added
                 to the time generated to get the verified time which is used as the index for the data
+
+            TODO  Remove this once the API returns the lead time
             '''
             model_name = value['modelName']
             match = re.search(r'(\d+)hr', model_name)

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -140,7 +140,7 @@ class SemaphoreOutputStatistics(IDataIngestion):
                 ...
             }
 
-        :returns: dataframe - the dataframe with the new data added
+        :returns: dataframe - the ongoing dataframe with the new data joined to it
         '''
         logger = thread_storage.logger
 
@@ -154,7 +154,15 @@ class SemaphoreOutputStatistics(IDataIngestion):
                 to the time generated to get the verified time which is used as the index for the data
             '''
             model_name = value['modelName']
-            lead_time = int(re.search(r'(\d+)hr', model_name).group(1))
+            match = re.search(r'(\d+)hr', model_name)
+            if match:
+                lead_time = int(match.group(1))
+            else:
+                # in the case that a lead time isn't able to be extracted
+                # return the unmodified dataframe and log a warning
+                logger.log_info(f'Warning:: Could not extract lead time from model name {model_name}')
+                return df
+            
             timeGenerated = datetime.strptime(value['timeGenerated'], '%Y-%m-%dT%H:%M:%S')
             verifiedTime = timeGenerated + timedelta(hours=lead_time)
 

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -29,16 +29,10 @@ class SemaphoreOutputStatistics(IDataIngestion):
 
         :returns: dataframe - a new dataframe with the ingested data added
         '''
-        url = self.__prepare_url(model_names)
 
+        url = self.__prepare_url(model_names)
         response = api_request(url)
         validated_response = self.__validate_response(response)
-
-        if validated_response is None:
-            for stat in self.STATISTICS:
-                data = add_empty_column(data, f"Water Temperature Prediction {stat}")
-            return data
-
         return self.__add_data(df= data, response=validated_response)
 
 
@@ -65,7 +59,8 @@ class SemaphoreOutputStatistics(IDataIngestion):
     def __validate_response(self, response: dict) -> dict[str, dict] | None:
         '''
         This function validates the response from the semaphore API by checking for
-        empty responses and missing data
+        empty responses and missing data then retuns a dictionary containing only valid data
+        that has statistics or None if no valid data is present
 
         :params response: dict - the response from the API request
             the response will look like 
@@ -91,18 +86,19 @@ class SemaphoreOutputStatistics(IDataIngestion):
                 ...
             }
 
-        :returns dict[str, dict] - a dictionary containing only valid data that has statistics or None if no valid data is present
+        :returns dict[str, dict] | None - a dictionary containing only valid data that has statistics or None if no valid data is present
         '''
         logger = thread_storage.logger
         validated_response = {}
 
-        if response is None: 
+        if response is None:
+            logger.log_info('Warning:: Failed to ingest statistics response from the Semaphore API!')
             return None
         
         # filter out nulls in the response to only include models that compute statistics
         for key, value in response.items():
             if value is None:
-                logger.log_info(f'Warning:: Model {key} missing in returned data!')
+                logger.log_info(f'Warning:: Model statistics for key: {key} missing in returned data!')
                 continue
             else:
                 validated_response[key] = value
@@ -119,7 +115,7 @@ class SemaphoreOutputStatistics(IDataIngestion):
         Takes the validated response dict and adds it into the dataframe
 
         :param df: dataframe - the dataframe to add the data to
-        :param response: dict[str, dict] - the validated response from the API request
+        :param response: dict[str, dict] | None - the validated response from the API request or None if the response was invalid
             the response will look like 
             {
                 "CRPS_6hr": {
@@ -145,6 +141,11 @@ class SemaphoreOutputStatistics(IDataIngestion):
         :returns: dataframe - the ongoing dataframe with the new data joined to it
         '''
         logger = thread_storage.logger
+
+        # if there is no valid data to add, then add empty columns into the dataframe and return it
+        if response is None:
+            df[[f"Water Temperature Prediction {stat}" for stat in self.STATISTICS]] = np.nan
+            return df
 
         rows = []
         for _, value in response.items():
@@ -175,8 +176,7 @@ class SemaphoreOutputStatistics(IDataIngestion):
 
         # catch cases where models do give a valid response but all regex extractions fail
         if df_stats.empty:
-            for stat in self.STATISTICS:
-                df = add_empty_column(df, f"Water Temperature Prediction {stat}")
+            df[[f"Water Temperature Prediction {stat}" for stat in self.STATISTICS]] = np.nan
             return df
 
         df_stats = DataFrame(rows).set_index('verifiedTime')

--- a/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
+++ b/backend/Ingestion/IngestionClasses/SemaphoreOutputStatistics.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+# SemaphoreOutputStatistics.py
+# Created By: Christian Quintero
+# Created On: 05/13/2026
+"""
+This class ingests data from the output_statistics endpoint of the Semaphore API.
+NOTE:: reads the env "SEMAPHORE_API_URL" for the base url to hit.
+"""
+from Ingestion.I_Ingestion import IDataIngestion
+from datetime import datetime, timedelta
+from Ingestion.Ingestion_Utility import api_request, add_empty_column
+from flareRunner import thread_storage 
+from pandas import DataFrame
+from os import getenv
+import numpy as np
+import re
+
+
+class SemaphoreOutputStatistics(IDataIngestion):
+    STATISTICS = ['p1', 'p5', 'p10', 'p25', 'p50', 'p75', 'p90', 'p95', 'p99', 'min', 'max', 'mean', 'std_dev']
+
+    def ingest_data(self, data: DataFrame, ref_time: datetime, model_names: list[str]):
+        '''
+        Ingests data from a Semaphore API endpoint
+
+        :param data: dataframe - the dataframe object to fill with data
+        :param ref_time: datetime - the reference time for the data request
+        :param model_names: list[str] - the names of the models to request data for
+
+        :returns: dataframe - a new dataframe with the ingested data added
+        '''
+        url = self.__prepare_url(model_names)
+
+        response = api_request(url)
+        is_valid_response = self.__validate_response(response, model_names)
+        if not is_valid_response:
+            return add_empty_column(data, "Water Temperature Prediction Statistics")
+
+        return self.__add_data(df= data, response=response, model_names=model_names)
+
+
+    def __prepare_url(self, model_names: list[str]) -> str:
+        '''
+        This function builds the URl for the API request based on the model names provided
+
+        :params model_names: list[str] - the names of the models to request data for
+
+        :returns: str - the URL to hit for the API request
+        '''
+
+        # the base url for the semaphore api, already ending with a slash
+        base_url = getenv("SEMAPHORE_API_URL")
+        url = f'{base_url}output_statistics/?'
+
+        # append each model name as a query parameter
+        # the resulting url will look like
+        # https://sherlock-prod.tamucc.edu/semaphore-api/output_statistics/?modelNames=CRPS_6hr&modelNames=MRE_Bird-Island_Water-Temperature_120hr&
+        for model_name in model_names: url += f'modelNames={model_name}&'
+        return url[:-1]  # remove the trailing '&'
+    
+
+    def __validate_response(self, response: list[dict], model_names: list[str]) -> bool:
+        '''
+        This function validates the response from the semaphore API by checking for
+        empty responses and missing data
+
+        :params response: list[dict] - the response from the API request
+            the response will look like 
+            [
+                {
+                    "modelName": "CRPS_6hr",
+                    "timeGenerated": "2026-05-12T12:00:00+00:00",
+                    "p1": 25.20813787460327,
+                    "p5": 25.744343280792236,
+                    "p10": 25.94855365753174,
+                    "p25": 26.22447681427002,
+                    "p50": 26.485905647277832,
+                    "p75": 26.73847484588623,
+                    "p90": 27.00280132293701,
+                    "p95": 27.201376342773436,
+                    "p99": 27.95702182769775,
+                    "min": 22.700056076049805,
+                    "max": 29.92579460144043,
+                    "mean": 26.486501573524475,
+                    "std_dev": 0.48822468208073955
+                },
+                ...
+            ]
+        :params model_names: list[str] - the names of the models we queried for
+
+        :returns: bool
+            - true if we got a valid response, even if there is missing data
+            - false if the response was empty
+        '''
+        logger = thread_storage.logger
+
+        if response is None: 
+            return False
+        
+        for dict in response:
+            model_name = dict.get("modelName")
+            if model_name is None: 
+                logger.log_info(f'Warning:: Model {model_name} missing in returned data!')
+                continue
+
+        return True
+    
+    
+    def __add_data(self, df: DataFrame, response: list[dict], model_names: list[str]) -> DataFrame:
+        '''
+        Takes the data returned by the semaphore API and parses it into the dataframe
+
+        :param df: dataframe - the dataframe to add the data to
+        :param response: list[dict] - the response from the API request
+            the response will look like 
+                [
+                    {
+                        "modelName": "CRPS_6hr",
+                        "timeGenerated": "2026-05-12T12:00:00+00:00",
+                        "p1": 25.20813787460327,
+                        "p5": 25.744343280792236,
+                        "p10": 25.94855365753174,
+                        "p25": 26.22447681427002,
+                        "p50": 26.485905647277832,
+                        "p75": 26.73847484588623,
+                        "p90": 27.00280132293701,
+                        "p95": 27.201376342773436,
+                        "p99": 27.95702182769775,
+                        "min": 22.700056076049805,
+                        "max": 29.92579460144043,
+                        "mean": 26.486501573524475,
+                        "std_dev": 0.48822468208073955
+                    },
+                    ...
+                ]
+        :param model_names: list[str] - the names of the models we queried for
+
+        :returns: dataframe - the dataframe with the new data added
+        '''
+        logger = thread_storage.logger
+
+        rows = []
+        for dict in response:
+            model_name  = dict['modelName']
+            ############################
+            # DONT FORGET TO REMOVE THE TZ INFO AFTER JOY UPDATES THE API
+            ############################
+            timeGenerated = datetime.strptime(dict['timeGenerated'], '%Y-%m-%dT%H:%M:%S%z')
+            timeGenerated = timeGenerated.replace(tzinfo=None) # remove timezone info for easier handling
+            
+            '''
+            since the lead time isn't explicitly given in the response, we have to
+            calculate it since the lead times are tied to the model name
+            
+            Ex) CRPS_6hr has a lead time of 6 hours, so the 6 is extracted and 6 hours are added
+                to the time generated to get the verified time which is used as the index for the data
+            '''
+            lead_time = int(re.search(r'(\d+)hr', model_name).group(1))
+            verifiedTime = timeGenerated + timedelta(hours=lead_time)
+            row = {'verifiedTime': verifiedTime}
+            for stat in self.STATISTICS:
+                row[f'Water Temperature Prediction {stat}'] = dict.get(stat, np.nan)
+            rows.append(row)
+
+        df_stats = DataFrame(rows).set_index('verifiedTime')
+
+        # Add this to the collation df with an outerjoin to ensure all data is preserved
+        return df.join(df_stats, how='outer')

--- a/backend/Ingestion/Ingestion_Utility.py
+++ b/backend/Ingestion/Ingestion_Utility.py
@@ -4,10 +4,9 @@ from numpy import nan
 from pandas import DataFrame
 import json
 from runtimeContext import thread_storage
-import ssl
 
 
-def api_request( url: str) -> dict[any] | None:
+def api_request(url: str) -> dict | None:
     """
     Execute a web get request returning the response or None if the request fails
 

--- a/backend/Ingestion/Ingestion_Utility.py
+++ b/backend/Ingestion/Ingestion_Utility.py
@@ -7,17 +7,17 @@ from runtimeContext import thread_storage
 import ssl
 
 
-def api_request( url: str):
+def api_request( url: str) -> dict[any] | None:
+    """
+    Execute a web get request returning the response or None if the request fails
 
-    """Execute a web get request against  URL returning the response or Non.
-    :param url: str 
+    :param url: str - the url to request data from
 
+    :returns: dict[any] | None - the response from the request as a dictionary, or None if the request fails
     """
     logger = thread_storage.logger
     try:
-        # As of writing this 10/26/2025 sherlock-dev has no ssl cert, so if we are hitting the dev server we disable ssl verification
-        context = ssl.create_default_context() if not "sherlock-dev" in url else ssl._create_unverified_context()
-        with urlopen(url, context=context) as response:
+        with urlopen(url) as response:
             data = json.loads(''.join([line.decode() for line in response.readlines()])) #Download and parse
         return data
     except HTTPError as err:

--- a/backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py
+++ b/backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py
@@ -20,8 +20,10 @@ from Ingestion.IngestionClasses.SemaphoreOutputStatistics import SemaphoreOutput
 # fixture for the logger
 @pytest.fixture(autouse=True)
 def mock_logger():
-    with patch('Ingestion.IngestionClasses.SemaphoreOutputStatistics.thread_storage') as mock_storage:
+    with patch('Ingestion.IngestionClasses.SemaphoreOutputStatistics.thread_storage') as mock_storage, \
+        patch('Ingestion.Ingestion_Utility.thread_storage') as mock_utility_storage:
         mock_storage.logger = MagicMock()
+        mock_utility_storage.logger = MagicMock()
         yield mock_storage
 
 @pytest.mark.parametrize("response, expected", [
@@ -273,9 +275,10 @@ def test_validate_response(response, expected):
     (
         # ongoing
         DataFrame({
+            'verifiedTime': [datetime(2026, 1, 1, 12, 0, tzinfo=None)],
             'Air Temperature Prediction': [50],
         },
-        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None)]
+        index=['verifiedTime']
         ),
         # response
         {
@@ -297,11 +300,25 @@ def test_validate_response(response, expected):
                 "std_dev": 13
             }
         },
-        # expected df - should be unchanged
+        # expected df now has empty columns for each stat
         DataFrame({
+            'verifiedTime': [datetime(2026, 1, 1, 12, 0, tzinfo=None)],
             'Air Temperature Prediction': [50],
+            'Water Temperature Prediction p1': [nan],
+            'Water Temperature Prediction p5': [nan],
+            'Water Temperature Prediction p10': [nan],
+            'Water Temperature Prediction p25': [nan],
+            'Water Temperature Prediction p50': [nan],
+            'Water Temperature Prediction p75': [nan],
+            'Water Temperature Prediction p90': [nan],
+            'Water Temperature Prediction p95': [nan],
+            'Water Temperature Prediction p99': [nan],
+            'Water Temperature Prediction min': [nan],
+            'Water Temperature Prediction max': [nan],
+            'Water Temperature Prediction mean': [nan],
+            'Water Temperature Prediction std_dev': [nan]
         },
-        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None)]
+        index=['verifiedTime']
         )
     )],
     ids=[

--- a/backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py
+++ b/backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+# test_SemaphoreOutputStatistics.py
+# Created By: Christian Quintero
+# Created On: 05/18/2026
+"""
+Tests the SemaphoreOutputStatistics class functions
+
+docker exec flare-backend python3 -m pytest ./backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py -s
+
+NOTE:: reads the env "SEMAPHORE_API_URL" for the base url to hit.
+"""
+import pytest
+from pandas import DataFrame
+from numpy import nan
+from datetime import datetime
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from Ingestion.IngestionClasses.SemaphoreOutputStatistics import SemaphoreOutputStatistics
+
+# fixture for the logger
+@pytest.fixture(autouse=True)
+def mock_logger():
+    with patch('Ingestion.IngestionClasses.SemaphoreOutputStatistics.thread_storage') as mock_storage:
+        mock_storage.logger = MagicMock()
+        yield mock_storage
+
+@pytest.mark.parametrize("response, expected", [
+    # all valid responses
+    (
+        # test response
+        {
+            "model1": {
+                "modelName": "Model1_6hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            },
+            "model2": {
+                "modelName": "Model2_12hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            }
+        },
+        # expected output
+        {
+            "model1": {
+                "modelName": "Model1_6hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            },
+            "model2": {
+                "modelName": "Model2_12hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            }
+        }
+    ),
+
+    # some null response
+    (
+        {
+            "model1": {
+                "modelName": "Model1_6hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            },
+            "model_that_doesnt_exit": None
+        },
+        {
+            "model1": {
+                "modelName": "Model1_6hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            }
+        }
+    ),
+
+    # all null responses
+    (
+        {
+            "model_that_doesnt_exit": None,
+            "another_model_that_doesnt_exist": None
+        },
+        None
+    )],
+    ids=[
+        "all_valid_responses",
+        "some_null_response",
+        "all_null_responses"
+    ]
+)
+def test_validate_response(response, expected):
+    """
+    tests the validate_response function of the SemaphoreOutputStatistics class to ensure
+    the null responses are filtered out properly
+
+    :param response: dict[str, dict] - the response from the API request that needs to be validated
+    :param expected: dict[str, dict] - the expected output from the validate_response function given the input response
+    """
+
+    sos = SemaphoreOutputStatistics()
+    result = sos._SemaphoreOutputStatistics__validate_response(response)
+    assert result == expected
+
+
+@pytest.mark.parametrize("ongoing_df, response, expected_df", [
+    # test adding data to an empty dataframe
+    (
+        # the ongoing dataframe to add to
+        DataFrame(),
+        # the validated response to add to the dataframe
+        {
+            "model1_6hr": {
+                "modelName": "Model1_6hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            }
+        },
+        # the expected dataframe after adding the data
+        DataFrame(
+            {
+                'Water Temperature Prediction p1': [1],
+                'Water Temperature Prediction p5': [2],
+                'Water Temperature Prediction p10': [3],
+                'Water Temperature Prediction p25': [4],
+                'Water Temperature Prediction p50': [5],
+                'Water Temperature Prediction p75': [6],
+                'Water Temperature Prediction p90': [7],
+                'Water Temperature Prediction p95': [8],
+                'Water Temperature Prediction p99': [9],
+                'Water Temperature Prediction min': [10],
+                'Water Temperature Prediction max': [11],
+                'Water Temperature Prediction mean': [12],
+                'Water Temperature Prediction std_dev': [13]
+            },
+            # this index is 18 hours because the lead time in this test is 6 hours
+            # added onto the time generated to get (12:00 + 6 hours = 18:00)
+            index=[datetime(2026, 1, 1, 18, 0, tzinfo=None)]
+        )
+    ),
+    # test adding data to a non-empty df
+    (
+        # ongoing
+        DataFrame({
+            'Air Temperature Prediction': [50],
+        },
+        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None)]
+        ),
+        # response
+        {
+            "model1_12hr": {
+                "modelName": "Model1_12hr",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 20,
+                "p5": 21,
+                "p10": 22,
+                "p25": 23,
+                "p50": 24,
+                "p75": 25,
+                "p90": 26,
+                "p95": 27,
+                "p99": 28,
+                "min": 29,
+                "max": 30,
+                "mean": 31,
+                "std_dev": 32
+            }
+        },
+        # expected df
+        DataFrame({
+            'Air Temperature Prediction': [50, nan],
+            'Water Temperature Prediction p1': [nan, 20],
+            'Water Temperature Prediction p5': [nan, 21],
+            'Water Temperature Prediction p10': [nan, 22],
+            'Water Temperature Prediction p25': [nan, 23],
+            'Water Temperature Prediction p50': [nan, 24],
+            'Water Temperature Prediction p75': [nan, 25],
+            'Water Temperature Prediction p90': [nan, 26],
+            'Water Temperature Prediction p95': [nan, 27],
+            'Water Temperature Prediction p99': [nan, 28],
+            'Water Temperature Prediction min': [nan, 29],
+            'Water Temperature Prediction max': [nan, 30],
+            'Water Temperature Prediction mean': [nan, 31],
+            'Water Temperature Prediction std_dev': [nan, 32]
+        },
+        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None), datetime(2026, 1, 2, 0, 0, tzinfo=None)]
+        )
+    ),
+    # test a model name with missing lead time
+    (
+        # ongoing
+        DataFrame({
+            'Air Temperature Prediction': [50],
+        },
+        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None)]
+        ),
+        # response
+        {
+            "model_with_no_lead_time": {
+                "modelName": "ModelWithNoLeadTime",
+                "timeGenerated": "2026-01-01T12:00:00",
+                "p1": 1,
+                "p5": 2,
+                "p10": 3,
+                "p25": 4,
+                "p50": 5,
+                "p75": 6,
+                "p90": 7,
+                "p95": 8,
+                "p99": 9,
+                "min": 10,
+                "max": 11,
+                "mean": 12,
+                "std_dev": 13
+            }
+        },
+        # expected df - should be unchanged
+        DataFrame({
+            'Air Temperature Prediction': [50],
+        },
+        index=[datetime(2026, 1, 1, 12, 0, tzinfo=None)]
+        )
+    )],
+    ids=[
+        "add_to_empty",
+        "add_to_non_empty",
+        "missing_lead_time"
+    ]
+)
+def test_add_data(ongoing_df, response, expected_df):
+    """
+    tests the __add_data function of the SemaphoreOutputStatistics class to ensure
+    the data is added to the dataframe properly
+
+    :param ongoing_df: dataframe - the ongoing dataframe to add the data to
+    :param response: dict[str, dict] - the validated response from the API request that needs to be added to the dataframe
+    :param expected_df: dataframe - the expected dataframe after adding the data
+    """
+
+    sos = SemaphoreOutputStatistics()
+    result_df = sos._SemaphoreOutputStatistics__add_data(ongoing_df, response)
+    assert result_df.equals(expected_df)

--- a/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
+++ b/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
@@ -67,7 +67,7 @@
         "args": {
             "col_name": "Air Temperature Prediction",
             "interpolation_interval": 3600,
-            "limit": 21600
+            "limit": 10800
         }
       },
       {

--- a/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
+++ b/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
@@ -11,7 +11,6 @@
             "interval": 3600,
             "range": [-144, 0]
          }
-            
         },
         {  "key": "SemaphoreInputs",
          "args": {
@@ -22,7 +21,6 @@
             "interval": 3600,
             "range": [-144, 0]
          }
-            
         },
         {  "key": "SemaphoreInputs",
          "args": {
@@ -33,7 +31,6 @@
             "interval": 3600,
             "range": [0, 120]
          }
-            
         },
         {  "key": "SemaphoreOutputLatest",
          "args": {
@@ -61,8 +58,7 @@
               "Bird-Island_Water-Temperature_114hr",
               "Bird-Island_Water-Temperature_120hr"
             ] 
-          }
-            
+          }    
         }
     ],
     "post_processing" : [
@@ -71,7 +67,7 @@
         "args": {
             "col_name": "Air Temperature Prediction",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -79,10 +75,9 @@
         "args": {
             "col_name": "Water Temperature Prediction",
             "interpolation_interval": 3600,
-            "limit": 144000
+            "limit": 21600
         }
       }
-
     ],
     "csv_config": {
       "csv_name": "Laguna-Madre_Water-Level_Air-Temperature_120hrs.csv",

--- a/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json
+++ b/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json
@@ -11,7 +11,6 @@
             "interval": 3600,
             "range": [-144, 0]
          }
-            
         },
         {  "key": "SemaphoreInputs",
          "args": {
@@ -22,7 +21,6 @@
             "interval": 3600,
             "range": [-144, 0]
          }
-            
         },
         {  "key": "SemaphoreInputs",
          "args": {
@@ -33,7 +31,6 @@
             "interval": 3600,
             "range": [0, 120]
          }
-            
         },
         {  "key": "SemaphoreOutputLatest",
          "args": {
@@ -62,7 +59,6 @@
               "MRE_Bird-Island_Water-Temperature_120hr"
             ] 
           }
-            
         }
     ],
     "post_processing" : [
@@ -98,7 +94,7 @@
         "args": {
             "col_name": "Water Temperature Prediction 95th Percentile",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -107,7 +103,7 @@
         "args": {
             "col_name": "Water Temperature Prediction 5th Percentile",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -116,7 +112,7 @@
         "args": {
             "col_name": "Water Temperature Prediction Max",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -125,7 +121,7 @@
         "args": {
             "col_name": "Water Temperature Prediction Min",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -134,7 +130,7 @@
         "args": {
             "col_name": "Water Temperature Prediction Median",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       },
       {
@@ -143,7 +139,7 @@
         "args": {
             "col_name": "Air Temperature Prediction",
             "interpolation_interval": 3600,
-            "limit": 10800
+            "limit": 21600
         }
       }
     ],

--- a/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json
+++ b/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json
@@ -139,7 +139,7 @@
         "args": {
             "col_name": "Air Temperature Prediction",
             "interpolation_interval": 3600,
-            "limit": 21600
+            "limit": 10800
         }
       }
     ],

--- a/data/cspec/test_Semaphore-Output-Statistics.json
+++ b/data/cspec/test_Semaphore-Output-Statistics.json
@@ -1,0 +1,216 @@
+{
+    "chart_name": "test_Semaphore-Output-Latest",
+    "CSPEC_version": "1.0.0",
+    "data_requests" : [
+        {  
+            "key": "SemaphoreInputs",
+            "args": {
+                "column_name": "Water Temperature Measurement",
+                "location": "SBI", 
+                "source": "NOAATANDC",
+                "series": "dWaterTmp",
+                "interval": 3600,
+                "range": [-144, 0]
+            }    
+        },
+        {  
+            "key": "SemaphoreInputs",
+            "args": {
+                "column_name": "Air Temperature Measurement",
+                "location": "SBI",
+                "source": "NOAATANDC",
+                "series": "dAirTmp",
+                "interval": 3600,
+                "range": [-144, 0]
+            }  
+        },
+        {  
+            "key": "SemaphoreInputs",
+            "args": {
+                "column_name": "Air Temperature Prediction",
+                "location": "SBirdIsland", 
+                "source": "NDFD_JSON",
+                "series": "pAirTemp",
+                "interval": 3600,
+                "range": [0, 120]
+            }
+        },
+        {
+            "key": "SemaphoreOutputStatistics",
+            "args": {
+                "model_names": [
+                    "MRE_Bird-Island_Water-Temperature_3hr",
+                    "MRE_Bird-Island_Water-Temperature_6hr",
+                    "MRE_Bird-Island_Water-Temperature_12hr",
+                    "MRE_Bird-Island_Water-Temperature_18hr",
+                    "MRE_Bird-Island_Water-Temperature_24hr",
+                    "MRE_Bird-Island_Water-Temperature_30hr",
+                    "MRE_Bird-Island_Water-Temperature_36hr",
+                    "MRE_Bird-Island_Water-Temperature_42hr",
+                    "MRE_Bird-Island_Water-Temperature_48hr",
+                    "MRE_Bird-Island_Water-Temperature_54hr",
+                    "MRE_Bird-Island_Water-Temperature_60hr",
+                    "MRE_Bird-Island_Water-Temperature_66hr",
+                    "MRE_Bird-Island_Water-Temperature_72hr",
+                    "MRE_Bird-Island_Water-Temperature_78hr",
+                    "MRE_Bird-Island_Water-Temperature_84hr",
+                    "MRE_Bird-Island_Water-Temperature_90hr",
+                    "MRE_Bird-Island_Water-Temperature_96hr",
+                    "MRE_Bird-Island_Water-Temperature_102hr",
+                    "MRE_Bird-Island_Water-Temperature_108hr",
+                    "MRE_Bird-Island_Water-Temperature_114hr",
+                    "MRE_Bird-Island_Water-Temperature_120hr"
+                ] 
+            }
+        }
+    ],
+    "post_processing" : [
+      {
+        "_comment": "Interpolates the 1st percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p1",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 5th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p5",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 10th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p10",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 25th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p25",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 50th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p50",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 75th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p75",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 90th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p90",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 95th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p95",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates the 99th percentile statistic between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction p99",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates min values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction min",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates max values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction max",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates mean values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction mean",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates std_dev values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Water Temperature Prediction std_dev",
+            "interpolation_interval": 3600,
+            "limit": 21600
+        }
+      },
+      {
+        "_comment": "Interpolates air temperature predictions between the 21 lead time values",
+        "key": "LinearInterpolation",
+        "args": {
+            "col_name": "Air Temperature Prediction",
+            "interpolation_interval": 3600,
+            "limit": 10800
+        }
+      }
+    ],
+    "csv_config": {
+      "csv_name": "test_Semaphore-Output-Latest.csv",
+      "included_columns": [
+        "Air Temperature Measurement",
+        "Water Temperature Measurement",
+        "Air Temperature Prediction",
+        "Water Temperature Prediction p1",
+        "Water Temperature Prediction p5",
+        "Water Temperature Prediction p10",
+        "Water Temperature Prediction p25",
+        "Water Temperature Prediction p50",
+        "Water Temperature Prediction p75",
+        "Water Temperature Prediction p90",
+        "Water Temperature Prediction p95",
+        "Water Temperature Prediction p99",
+        "Water Temperature Prediction min",
+        "Water Temperature Prediction max",
+        "Water Temperature Prediction mean",
+        "Water Temperature Prediction std_dev"
+      ]
+    }
+  }


### PR DESCRIPTION
# Description
This ticket adds the new ingestion class for flare and tests it and also fixes a bug with interpolating in our previous charts.

# Changes
Laguna-Madre_Water-Level_Air-Temperature_120hrs.json
- removed some blank lines
- updated interpolation intervals to 6 hours (3600 * 6 = 21,600)

MRE_Bird-Island_Water-Temperature_Ribbon.json
- removed some blank lines
- updated interpolation intervals to 6 hours (3600 * 6 = 21,600)

Ingestion_Utility.py
- removed the SSL context stuff
- updated function signature return value
- updated function comments

SemaphoreOutputStatistics.py
- new ingestion class to query from the semaphore output_statistics endpoint

test_Semaphore-Output-Statistics.json
- a test cspec I made by modifying MRE_Bird-Island_Water-Temperature_Ribbon.json
- the ingestion call uses the new endpoint `SemaphoreOutputStatistics`
- the ingestion call has no `column_name` since this call appends many columns (for each statistic), not just 1 column
- interpolation is performed between all lead time statistics

test_SemaphoreOutputStatistics.py
- new unit test file 
- tests the response filtering and adding data to the ongoing dataframe

# To test the new ingestion

In a Semaphore terminal 
1. ensure your containers are running and built based on main
2. run all MRE models; see the command to paste below everything

In a flare terminal
1. `docker compose up --build -d`
2. `docker exec flare-backend python3 -m pytest ./backend/Tests/UnitTests/test_SemaphoreOutputStatistics.py -s`
3. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/test_Semaphore-Output-Statistics.json`

In the CSV file, make sure you see columns for
- Date (this is our verified time index which isn't a column like the others but shows in our CSVs)
- Air Temperature Measurement
- Water Temperature Measurement 
- Air Temperature Prediction,
- Water Temperature Prediction p1
- Water Temperature Prediction p5
- Water Temperature Prediction p10
- Water Temperature Prediction p25
- Water Temperature Prediction p50
- Water Temperature Prediction p75
- Water Temperature Prediction p90
- Water Temperature Prediction p95
- Water Temperature Prediction p99
- Water Temperature Prediction min
- Water Temperature Prediction max
- Water Temperature Prediction mean
- Water Temperature Prediction std_dev

Ensure all gaps between the lead times we predict are interpolated properly. Ex
<img width="2778" height="464" alt="image" src="https://github.com/user-attachments/assets/64d407f6-bae5-4d13-88a9-8d9bed833959" />


# The Bug portion description
The interpolation in Laguna Madre and Ensemble graphs wasn't working properly since the interpolation limit was set incorrectly for them. This caused our CSV's to only include the predictions for the lead times we calculate and have gaps in our data as shown below
<img width="1300" height="726" alt="image" src="https://github.com/user-attachments/assets/a56638a8-4e45-4be8-8dc0-0b81734b0337" />

To be a bit more specific, the Laguna Madre graph interpolates air temp predictions for 3 hour gaps. In practice we get a prediction for every hour from NDFD_JSON, so the interpolation doesn't do anything. For this one I only updated the interpolation limit by increasing it to match the others, but I am open to remove it from the cspecs if we desire. 

For Laguna Madre Water temp predictions, the bug was that the interpolation limit was set incorrectly to interpolate gaps up to 40 hours wide, which was most likely the result of an extra 0. Anyways, I updated this to interpolate 6 hour intervals as we expect

For Ensemble graphs, the limits were set to interpolate 3 hour gaps, but our lead times predict 6 hour gaps causing only the gap between the 3hr and 6hr models to be interpolated and gaps between everything else. I increased these to 6 hours so we interpolate these gaps.

Ex) we predict a lead time for 6 hours and 12 hours, so the interpolation interpolates hours 7, 8, 9, 10, and 11. 

# Testing the bug fix with interpolation
1. In semaphore run all legacy and MRE cold stunning models
2. Then in flare,
3. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/Laguna-Madre_Water-Level_Air-Temperature_120hrs.json`
4. `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/MRE_Bird-Island_Water-Temperature_Ribbon.json`

In the CSV's you should see that we interpolate the predictions properly now. 
<img width="2478" height="678" alt="image" src="https://github.com/user-attachments/assets/f2b0f283-ddc5-4468-86e8-7c2e62b6b157" />

# all models
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json`

`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json`
