### PR TITLE
Visual changes

### DIFF
--- a/vue-ui/src/views/SouthBirdIslandChartView.vue
+++ b/vue-ui/src/views/SouthBirdIslandChartView.vue
@@ -697,16 +697,16 @@ onUnmounted(() => {
         <a href="https://www.coastaldynamicslab.org/" target="_blank" class="hover:scale-110 transition-transform">
           <img src="@/assets/images/CDL-Logo.png" alt="Coastal Dynamics Lab Logo" class="max-w-[80px] lg:max-w-[150px]">
         </a>
-        <a href="https://www.nps.gov/index.htm" target="_blank">
+        <a href="https://www.nps.gov/index.htm" target="_blank" class="hover:scale-110 transition-transform">
           <img class="footer-logo" src="@/assets/images/NPS-Logo.png" alt="National Park Service Logo">
         </a>
-        <a href="https://www.weather.gov/" target="_blank">
+        <a href="https://www.weather.gov/" target="_blank" class="hover:scale-110 transition-transform">
           <img src="@/assets/images/NWS-Logo.png" alt="National Weather Service Logo" class="max-w-[80px] lg:max-w-[150px]">
         </a>
-        <a href="https://www.uscg.mil/" target="_blank">
+        <a href="https://www.uscg.mil/" target="_blank" class="hover:scale-110 transition-transform">
           <img  src="@/assets/images/CG-Logo.png" alt="USA Coast Guard Logo" class="max-w-[80px] lg:max-w-[150px]">
         </a>
-        <a href="https://www.joincca.org/" target="_blank">
+        <a href="https://www.joincca.org/" target="_blank" class="hover:scale-110 transition-transform">
           <img src="@/assets/images/CCA-Logo.png" alt="Coastal Conservation Association Logo" class="max-w-[80px] lg:max-w-[150px]">
         </a>
       </div>

--- a/vue-ui/src/views/WaterTemperatureEnsembleView.vue
+++ b/vue-ui/src/views/WaterTemperatureEnsembleView.vue
@@ -339,7 +339,7 @@ const fetchAndFilterData = async () => {
         color: "black",
         dashStyle: "Dash",
         lineWidth: isSmallScreen ? 1.9 : 2.5,
-        zIndex: 1, // Ensure this is in front of the bounds
+        zIndex: 2, // Ensure this is in front of the bounds
         marker: { enabled: false },
       },
       {
@@ -349,8 +349,8 @@ const fetchAndFilterData = async () => {
         //linkedTo: "Water Temperature Predictions", //not sure why we wanted to linked them but it does not seem necessary and was not allowing the ribbon to be toggled on and off
         lineWidth: 1.9, // No line for bounds
         color: "#00a0ff",
-        fillOpacity: 0.3,
-        zIndex: 0, // Ensure this is underneath the mean line
+        fillOpacity: .78,
+        zIndex: 1, // Ensure this is underneath the mean line
         marker: { enabled: false },
       },
       {
@@ -371,6 +371,7 @@ const fetchAndFilterData = async () => {
         name: "Interpolated Predicted Air Temperature",
         data: forecastAirTempsFahrenheit,
         color: "orange",
+        zIndex: 0,
         dashStyle: "Dash", // Shorter dashes
         lineWidth: isSmallScreen ? 1.9 : 2.5,
         marker: { enabled: false },


### PR DESCRIPTION
## Problem 1
Move ribbon in front of interpolated air temp on water temp predictions ribbon graph
<img width="622" height="333" alt="Image" src="https://github.com/user-attachments/assets/ccc6aa3d-cc30-45ee-821c-0567fe2b8472" />

### Fix

The image below show's what it looks like when I simply place the orange line behind the ribbon, but since the ribbon is see through the line can still be seen:
<img width="506" height="107" alt="Image" src="https://github.com/user-attachments/assets/61c4f9c3-f67b-4f94-9eff-5bb098f0a438" />

So, I decided to make it more opaque:

<img width="562" height="310" alt="Image" src="https://github.com/user-attachments/assets/c1184ceb-8c77-4fce-be86-7b8b20cd560e" />


---
## Problem 2
On flare, some of the stakeholder logos do not grow when you hover over them. https://sherlock-prod.tamucc.edu/flare/south-bird-island
This occurs for 
* national park service
* national weather service
* US coast guard 
* coastal conservation association


### These 
<img width="2880" height="1070" alt="Image" src="https://github.com/user-attachments/assets/dbf85387-a862-4f6b-82d9-70e36934cb01" />


### Fix
 All logos grow when hovered over