### PR TITLE
Improved visual details of CRPS chart

### DIFF
--- a/vue-ui/src/views/CrpsView.vue
+++ b/vue-ui/src/views/CrpsView.vue
@@ -1439,7 +1439,7 @@ onUnmounted(() => {
                 </li>
               </ul>
             </div> <!-- End Right Card -->
-          </div> <! -- End Card Grind -->
+          </div> <!-- End Card Grind -->
 
         </div>
 

--- a/vue-ui/src/views/CrpsView.vue
+++ b/vue-ui/src/views/CrpsView.vue
@@ -1439,7 +1439,7 @@ onUnmounted(() => {
                 </li>
               </ul>
             </div> <!-- End Right Card -->
-          </div> <!-- End Card Grind -->
+          </div> <!-- End Card Grid -->
 
         </div>
 

--- a/vue-ui/src/views/CrpsView.vue
+++ b/vue-ui/src/views/CrpsView.vue
@@ -735,7 +735,7 @@ const fetchAndFilterData = async () => {
         marker: { enabled: true,symbol: 'triangle-down', radius: 3.5},
       },
       {
-        name: 'Predicition Range Min',
+        name: 'Prediction Range Min',
         data: waterPredictionsPercentileMinFahrenheit,
         type: "line",
         color: "#4A90E2",

--- a/vue-ui/src/views/CrpsView.vue
+++ b/vue-ui/src/views/CrpsView.vue
@@ -1311,7 +1311,7 @@ onUnmounted(() => {
         </div>
     </section>
 
-     <!-- Information Section -->
+    <!-- Information Section -->
 
 
 
@@ -1351,91 +1351,95 @@ onUnmounted(() => {
         >
 
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-
-            <!-- LEFT CARD -->
+              <!-- Left Card -->
               <div class="lg:col-span-1 bg-white p-6 rounded-lg shadow-md">
-          <h3 class="text-xl lg:text-2xl font-extrabold text-center lg:text-left text-dark-text border-b-2 border-gray-500 pb-2 mb-3 lg:pb-4 lg:mb-6">
-            Data on this Graph:
-          </h3>
-          <ul class="list-disc list-inside space-y-2 text-md lg:text-xl text-dark-text">
-            <li>
-              Past six-day air/water temperature from
-              <a href="https://tidesandcurrents.noaa.gov/stationhome.html?id=8776139" 
-                class="underline text-blue-600 hover:text-blue-800" target="_blank">NOAA's South Bird Island Station</a>
-            </li>
-            <li>
-              Backup water temperature data from
-              <a href="https://lighthouse.tamucc.edu/overview/171" 
-                class="underline text-blue-600 hover:text-blue-800" target="_blank">National Park Service</a>
-            </li>
-            <li>Air temperature predictions from the National Digital Forecast Database (points)</li>
-            <li>Cubic interpolation of predicted air temperature (dashed line)</li>
-            <li>Water temperature predictions from Semaphore (dashed line)</li>
-          </ul>
-        </div>
+                <h3 class="text-xl lg:text-2xl font-extrabold text-center lg:text-left text-dark-text border-b-2 border-gray-500 pb-2 mb-3 lg:pb-4 lg:mb-6">
+                  Data on this Graph:
+                </h3>
+                <ul class="list-disc list-inside space-y-2 text-md lg:text-xl text-dark-text">
+                  <li>
+                    Past six-day air/water temperature from
+                    <a href="https://tidesandcurrents.noaa.gov/stationhome.html?id=8776139" 
+                      class="underline text-blue-600 hover:text-blue-800" target="_blank">NOAA's South Bird Island Station</a>
+                  </li>
+                  <li>
+                    Backup water temperature data from
+                    <a href="https://lighthouse.tamucc.edu/overview/171" 
+                      class="underline text-blue-600 hover:text-blue-800" target="_blank">National Park Service</a>
+                  </li>
+                  <li>Air temperature predictions from the National Digital Forecast Database (points)</li>
+                  <li>Cubic interpolation of predicted air temperature (dashed line)</li>
+                  <li>Water temperature predictions from Semaphore (dashed line)</li>
+                </ul>
+              </div> <!-- End Left Card -->
 
-        <!-- Right Column -->
-        <div class="lg:col-span-1 bg-white p-6 rounded-lg shadow-md">
-          <h3 class="text-xl lg:text-2xl font-extrabold text-center lg:text-left text-dark-text border-b-2 border-gray-500 pb-2 mb-3 lg:pb-4 lg:mb-6">
-            Additional Information:
-          </h3>
-          <ul class="list-disc space-y-2 pl-5 text-md lg:text-xl text-dark-text">
-            <li>
-              Wind speed graph available 
-              <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">here</a>
-            </li>
-            <li>
-              Ensemble air temperature predictions from The Weather Company available 
-              <router-link 
-                to="/air-temperature-ensemble" 
-                class="underline text-blue-600 hover:text-blue-800">
-                here
-              </router-link>
-            </li>
-            <li>
-              Ensemble water temperature predictions from Semaphore available 
-              <router-link 
-                to="/water-temperature-ensemble" 
-                class="underline text-blue-600 hover:text-blue-800">
-                here
-              </router-link>
-            </li>
-            <li>
-              CRPS (Continuous Ranked Probability Score) ensemble model from Semaphore available
-              <router-link 
-                to="/crps" 
-                class="underline text-blue-600 hover:text-blue-800">
-                here
-              </router-link>
-            </li>
-            <li>
-              Wind predictions for the Laguna Madre available
-              <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">
-                here
-              </a>
-            </li>
-            <li>
-              Ensemble air temperature predictions for Bird Island Basin available 
-              <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">
-                here
-              </a>
-            </li>
-            <li>
-              AI water temperature prediction models performance available
-              <a href="https://lighthouse.tamucc.edu/supertool.php?stnid=013&elev=mwl&mode=nnwtp" target="_blank" class="underline text-blue-600 hover:text-blue-800">
-                here
-              </a>
-            </li>
-            <li>
-              NOAA Sea Turtle Stranding and Salvage Network water temperature measurements
-              <a href="https://connect.fisheries.noaa.gov/content/c0773132-9590-4e21-bb42-676e2140fbaa/" target="_blank" class="underline text-blue-600 hover:text-blue-800">
-                here
-              </a>
-            </li>
-          </ul>
-        </div>
-
-          </div>
+            <!-- Right Card -->
+            <div class="lg:col-span-1 bg-white p-6 rounded-lg shadow-md">
+              <h3 class="text-xl lg:text-2xl font-extrabold text-center lg:text-left text-dark-text border-b-2 border-gray-500 pb-2 mb-3 lg:pb-4 lg:mb-6">
+                Additional Information:
+              </h3>
+              <ul class="list-disc space-y-2 pl-5 text-md lg:text-xl text-dark-text">
+                <li>
+                  Wind speed graph available 
+                  <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">here</a>
+                </li>
+                <li>
+                  Ensemble air temperature predictions from The Weather Company available 
+                  <router-link 
+                    to="/air-temperature-ensemble" 
+                    class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </router-link>
+                </li>
+                <li>
+                  Ensemble water temperature predictions from Semaphore available 
+                  <router-link 
+                    to="/water-temperature-ensemble" 
+                    class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </router-link>
+                </li>
+                <li>
+                  CRPS (Continuous Ranked Probability Score) ensemble model from Semaphore available
+                  <router-link 
+                    to="/crps" 
+                    class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </router-link>
+                </li>
+                <li>
+                  Wind predictions for the Laguna Madre available
+                  <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </a>
+                </li>
+                <li>
+                  Ensemble air temperature predictions for Bird Island Basin available 
+                  <a href="https://cbigrid.tamucc.edu/tpw/graph-only-wind.html" target="_blank" class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </a>
+                </li>
+                <li>
+                  AI water temperature prediction models performance available
+                  <a href="https://lighthouse.tamucc.edu/supertool.php?stnid=013&elev=mwl&mode=nnwtp" target="_blank" class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </a>
+                </li>
+                <li>
+                  NOAA Sea Turtle Stranding and Salvage Network water temperature measurements
+                  <a href="https://connect.fisheries.noaa.gov/content/c0773132-9590-4e21-bb42-676e2140fbaa/" target="_blank" class="underline text-blue-600 hover:text-blue-800">
+                    here
+                  </a>
+                </li>
+                <li>
+                  Fog Prediction Model coming soon
+                </li>
+                <li>
+                  Inundation Prediction Model coming soon
+                </li>
+              </ul>
+            </div> <!-- End Right Card -->
+          </div> <! -- End Card Grind -->
 
         </div>
 

--- a/vue-ui/src/views/CrpsView.vue
+++ b/vue-ui/src/views/CrpsView.vue
@@ -277,7 +277,7 @@ const buildRibbonChart = (isSmallScreen, chartTitle) => {
                 
       },
       style: {
-        fontSize: isSmallScreen ? "10px" : "12px", 
+        fontSize: isSmallScreen ? "10px" : "16px", 
         padding: isSmallScreen ? "5px" : "8px", 
         color: "#0f4f66",
         fontFamily: "Arial",
@@ -397,7 +397,7 @@ const buildBoxChart = (isSmallScreen) => {
       endOnTick: true,
       tickInterval: 10, // Major ticks every 10 units
       min: 30, // Minimum value for y-axis
-      max: 100,
+      softMax: 90,
       title: {
         text: "Temperature (°F)",
         style: { 
@@ -476,7 +476,7 @@ const buildBoxChart = (isSmallScreen) => {
                 
       },
       style: {
-        fontSize: isSmallScreen ? "12px" : "14px", 
+        fontSize: isSmallScreen ? "12px" : "16px", 
         padding: isSmallScreen ? "5px" : "8px", 
         color: "#0f4f66",
         fontFamily: "Arial",
@@ -540,8 +540,12 @@ const fetchAndFilterData = async () => {
     const waterPredictionsPercentileMinFahrenheit = waterPredictionsPercentileMin.map(([time, celsius]) => [time, +toFahrenheit(celsius).toFixed(1)]);
     const waterPredictionsPercentileMaxFahrenheit = waterPredictionsPercentileMax.map(([time, celsius]) => [time, +toFahrenheit(celsius).toFixed(1)]);
 
-    const futureAirPredictionsFahrenheit =
-      airPredictionsFahrenheit.filter(([time]) => time >= Date.now());
+    /*
+    filter NDFD predictions to only include hours that align with CRPS lead time intervals
+    so the tooltip displays correctly
+    */
+    const crpsTimestamps = waterPredictionsPercentile50Fahrenheit.map(([time]) => time);
+    const futureAirPredictionsFahrenheit = airPredictionsFahrenheit.filter(([time]) => crpsTimestamps.includes(time) && time >= Date.now());
 
     // === Calculate bounds for the ribbon chart ===
     // Outer Ribbon(5th-95th)
@@ -702,7 +706,7 @@ const fetchAndFilterData = async () => {
       },
       {
         name: "NDFD Air Temperature Predictions",
-        data: airPredictionsFahrenheit,
+        data: futureAirPredictionsFahrenheit,
         type: "line",
         color: "orange",
         dashStyle: "LongDash",
@@ -751,15 +755,6 @@ const fetchAndFilterData = async () => {
         whiskerLength: '150%',
         color: '#4A90E2',
         fillColor: 'rgba(74,144,226,0.35)'
-      },
-      {
-        name: 'Prediction Range Max',
-        data: waterPredictionsPercentileMaxFahrenheit,
-        type: "line",
-        color: "#4A90E2",
-        lineWidth: 0,
-        zIndex: 1, // Ensure this is in front of the bounds
-        marker: { enabled: true,symbol: 'triangle-down', radius: 3.5},
       }
     ];
   } catch (error) {
@@ -1329,11 +1324,11 @@ onUnmounted(() => {
       <!-- Always-visible Handle -->
       <button
         @click="showInfoDrawer = !showInfoDrawer"
-        class="w-full bg-navy-blue text-white shadow-xl py-3"
+        class="w-[calc(100%-2rem)] mx-4 rounded-lg bg-[#1895a3] text-white border-4 border-black shadow-xl py-3"
       >
         <div class="w-12 h-1 bg-gray-300 rounded-full mx-auto mb-2"></div>
 
-        <div class="font-semibold">
+        <div class="font-semibold text-xl">
           {{ showInfoDrawer ? "Hide Additional Information ▼" : "Additional Information ▲" }}
         </div>
       </button>


### PR DESCRIPTION
# Ticket Description

- Bring CRPS lines in front of NDFD line on graphs
- Make additional info footer button more obvious
    - rounded edges
    - padding near edges
- increase font size of tooltips
- Inundation and Fog Coming Soon Buttons
- fix dashes on legend to look like dashes and not a straight line


# Changes

- increased tooltip font size to 16
- made additional info button more obvious
   - changed background color to a lighter color
   - added a dark outline color
   - added rounded edges
   - increased text size
- fixed softmax on box plot
   - some max water temp prediction values were being cut off due to this line missing
- removed a duplicate line on box plot
- filtered NDFD data to timestamps that align with CRPS to fix tooltip when hovering
   - see note below
- fixed indent levels on the additional info section
- added bullets for future inundation and fog models



# NDFD timestamp filtering reasoning

The issue with the CRPS lines and NDFD lines wasn't what we thought it was. We originally thought the issue was that NDFD was in front of CRPS due to the z index values. This was not the case as the CRPS charts are already set to be in front of the NDFD graphs.

The real issue, and the reason why it appeared that NDFD was in front of CRPS, is that NDFD has predictions for every hour while CRPS has predictions every 3 hours. When hovering over the chart, unless you were hovering over a 3 hour interval that CRPS predicted, it would most likely snap to the more granular 1 hour intervals of NDFD which made the tooltip only show NDFD since there is no CRPS value for that hour. 

The possible solutions I came up with were

- filter NDFD values to only include timestamps CRPS predicts for (what was implemented)
- interpolate CRPS predictions in the frontend to get a value for every hour
- do something complex to try and fix the tooltip

Between these options, I went with the simpler approach of either filter NDFD or interpolate CRPS, and then decided that filtering NDFD is the better of the 2 since then we are comparing NDFD's prediction to an authentic CRPS prediction instead of comparing NDFD to an interpolated CRPS value. Further, I also thought we would care more about how CRPS does against NDFD so the hours where we have an NDFD value but not a CRPS prediction, aren't useful to us so filtering and removing these seemed to be the best option to me.

# To Test

1. Point your semaphore api to dev (or manually run all CRPS models)
2. `docker compose up --build -d`
3. `docker exec flare-backend python3 /app/backend/flareRunner.py -v -c /app/data/cspec/CRPS_120hrs.json`
4. go to http://localhost:8080/flare/crps
5. On the first chart, trace your mouse over the predictions and see the tooltip font is much larger and all points the tooltip snaps to includes both CRPS and NDFD values
6. Do the same to the second chart and ensure the tooltip always shows CRPS points when hovering over predictions
7. Do the same to the third chart and ensure the tooltip always shows CRPS points when hovering over predictions
8. Ensure the box plot y axis correctly scales to 110 if any values are predicted above 100
9. Ensure the additional info button works when opening/closing, and links work
10. See the inundation and fog coming soon bullets on the additional info card


## Expected Results

<img width="2870" height="1492" alt="image" src="https://github.com/user-attachments/assets/d833d4a8-11f0-496e-80b1-8a0365dd5e5a" />

<img width="2880" height="1460" alt="image" src="https://github.com/user-attachments/assets/6a27ce38-fd28-43f6-871e-ed063013b1f4" />

<img width="2880" height="1470" alt="image" src="https://github.com/user-attachments/assets/c737048c-d44b-4ae3-9dcd-66549bdacdff" />

<img width="2880" height="1476" alt="image" src="https://github.com/user-attachments/assets/e5f3369b-5df9-46ee-8734-4e45e85c37d1" />
